### PR TITLE
Fix for Discrepancy in CostEstimate model for current android SDK (v1.0.3) (as reported on the lyft developer community forum)

### DIFF
--- a/networking/src/main/java/com/lyft/networking/ApiConfig.java
+++ b/networking/src/main/java/com/lyft/networking/ApiConfig.java
@@ -4,7 +4,7 @@ public class ApiConfig {
 
     private final String clientId;
     private final String clientToken;
-
+    private String userAccessToken;
     private ApiConfig(String clientId, String clientToken) {
         this.clientId = clientId;
         this.clientToken = clientToken;
@@ -23,6 +23,17 @@ public class ApiConfig {
     public String getClientToken() {
         return clientToken;
     }
+
+    /**
+     * @return Returns the user access token that was acquired through an oAuth authorize workflow
+     */
+    public String getUserAccessToken() { return userAccessToken; }
+
+    /**
+     * Sets the user access token that was acquired through an oAuth authorize workflow
+     * @param userAccessToken The user's access token
+     */
+    public void setUserAccessToken(String userAccessToken) { this.userAccessToken = userAccessToken; }
 
     public static class Builder {
 

--- a/networking/src/main/java/com/lyft/networking/LyftApiFactory.java
+++ b/networking/src/main/java/com/lyft/networking/LyftApiFactory.java
@@ -2,6 +2,9 @@ package com.lyft.networking;
 
 import com.lyft.networking.apis.LyftPublicApi;
 import com.lyft.networking.apis.LyftPublicApiRx;
+import com.lyft.networking.apis.LyftUserApi;
+import com.lyft.networking.apis.LyftUserApiRx;
+
 import okhttp3.OkHttpClient;
 import retrofit2.Retrofit;
 import retrofit2.adapter.rxjava.RxJavaCallAdapterFactory;
@@ -21,7 +24,7 @@ public class LyftApiFactory {
      * See: <a href="http://petstore.swagger.io/?url=https://api.lyft.com/v1/spec#!/Public/">http://petstore.swagger.io/?url=https://api.lyft.com/v1/spec#!/Public/</a>
      */
     public LyftPublicApi getLyftPublicApi() {
-        Retrofit retrofitPublicApi = getRetrofitBuilder().build();
+        Retrofit retrofitPublicApi = getRetrofitBuilder(getPublicOkHttpClient()).build();
         return retrofitPublicApi.create(LyftPublicApi.class);
     }
 
@@ -31,22 +34,52 @@ public class LyftApiFactory {
      * See: <a href="http://petstore.swagger.io/?url=https://api.lyft.com/v1/spec#!/Public/">http://petstore.swagger.io/?url=https://api.lyft.com/v1/spec#!/Public/</a>
      */
     public LyftPublicApiRx getLyftPublicApiRx() {
-        Retrofit retrofitPublicApi = getRetrofitBuilder()
+        Retrofit retrofitPublicApi = getRetrofitBuilder(getPublicOkHttpClient())
                 .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
                 .build();
         return retrofitPublicApi.create(LyftPublicApiRx.class);
     }
 
-    private Retrofit.Builder getRetrofitBuilder() {
+    /**
+     * @return An implementation of Lyft's User API endpoints that REQUIRE a user access token.
+     * The return type of API calls will be {@link retrofit2.Call}. Used by the LyftButton.
+     */
+
+    public LyftUserApi getLyftUserApi()
+    {
+        Retrofit retrofitUserApi = getRetrofitBuilder(getUserOkHttpClient()).build();
+        return retrofitUserApi.create(LyftUserApi.class);
+    }
+
+    /**
+     * @return An implementation of Lyft's User API endpoints that REQUIRE a user access token.
+     * The return type of API calls will be {@link rx.Observable}. Used by the LyftButton.
+     */
+    public LyftUserApiRx getLyftUserApiRx() {
+        Retrofit retrofitUserApi = getRetrofitBuilder(getUserOkHttpClient())
+                .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
+                .build();
+        return retrofitUserApi.create(LyftUserApiRx.class);
+    }
+
+    private Retrofit.Builder getRetrofitBuilder(OkHttpClient client) {
         return new Retrofit.Builder()
                 .baseUrl(LyftPublicApi.API_ROOT)
-                .client(getOkHttpClient())
+                .client(client)
                 .addConverterFactory(GsonConverterFactory.create());
     }
 
-    private OkHttpClient getOkHttpClient() {
+    private OkHttpClient getPublicOkHttpClient()
+    {
         return new OkHttpClient.Builder()
                 .addInterceptor(new RequestInterceptor(apiConfig.getClientToken()))
+                .build();
+    }
+
+    private OkHttpClient getUserOkHttpClient()
+    {
+        return new OkHttpClient.Builder()
+                .addInterceptor(new RequestInterceptor(apiConfig.getUserAccessToken()))
                 .build();
     }
 }

--- a/networking/src/main/java/com/lyft/networking/apiObjects/CostEstimate.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/CostEstimate.java
@@ -7,36 +7,72 @@ import com.google.gson.annotations.SerializedName;
  **/
 public class CostEstimate {
 
+    /**
+     * Ride type one of: (lyft, lyft_plus, lyft_line, lyft_premier, lyft_lux, lyft_luxsuv)
+     */
     @SerializedName("ride_type")
     public final String ride_type;
 
+    /**
+     * A human readable description of the ride type.
+     */
     @SerializedName("display_name")
     public final String display_name;
 
+    /***
+     *ISO 4217 currency code for the amount (e.g. USD).
+     */
     @SerializedName("currency")
     public final String currency;
 
+    /**
+     * Estimated lower bound for trip cost, in minor units (cents). Estimates are not guaranteed,
+     * and only provide a reasonable range based on current conditions.
+     */
     @SerializedName("estimated_cost_cents_min")
     public final Integer estimated_cost_cents_min;
 
+    /**
+     * Estimated upper bound for trip cost, in minor units (cents). Estimates are not guaranteed,
+     * and only provide a reasonable range based on current conditions.
+     */
     @SerializedName("estimated_cost_cents_max")
     public final Integer estimated_cost_cents_max;
 
+    /**
+     * Estimated distance for this ride as expressed in miles.
+     */
     @SerializedName("estimated_distance_miles")
     public final Double estimated_distance_miles;
 
+    /**
+     * Estimated time to get from the start location to the end as expressed in seconds.
+     */
     @SerializedName("estimated_duration_seconds")
     public final Integer estimated_duration_seconds;
 
+    /**
+     * The current primetime value
+     */
     @SerializedName("primetime_percentage")
     public final String primetime_percentage;
 
+    /**
+     * A token that should be used to confirm that the user has accepted current Prime Time
+     * and/or fixed price charges. See note above.
+     */
+    @SerializedName("cost_token")
+    public final String cost_token;
+
+    /**
+     * A token that should be used to confirm that the user has accepted current Prime Time pricing.
+     */
     @SerializedName("primetime_confirmation_token")
     public final String primetime_confirmation_token;
 
     public CostEstimate(String ride_type, String display_name, String currency, Integer estimated_cost_cents_min,
-            Integer estimated_cost_cents_max, Double estimated_distance_miles, Integer estimated_duration_seconds,
-            String primetime_percentage, String primetime_confirmation_token) {
+                        Integer estimated_cost_cents_max, Double estimated_distance_miles, Integer estimated_duration_seconds,
+                        String primetime_percentage, String primetime_confirmation_token, String cost_token) {
         this.ride_type = ride_type;
         this.display_name = display_name;
         this.currency = currency;
@@ -46,6 +82,7 @@ public class CostEstimate {
         this.estimated_duration_seconds = estimated_duration_seconds;
         this.primetime_percentage = primetime_percentage;
         this.primetime_confirmation_token = primetime_confirmation_token;
+        this.cost_token = cost_token;
     }
 
     @Override
@@ -62,6 +99,7 @@ public class CostEstimate {
         sb.append("  estimated_duration_seconds: ").append(estimated_duration_seconds).append("\n");
         sb.append("  primetime_percentage: ").append(primetime_percentage).append("\n");
         sb.append("  primetime_confirmation_token: ").append(primetime_confirmation_token).append("\n");
+        sb.append("  cost_token: ").append(cost_token).append("\n");
         sb.append("}\n");
         return sb.toString();
     }

--- a/networking/src/main/java/com/lyft/networking/apiObjects/EtaLocation.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/EtaLocation.java
@@ -1,0 +1,17 @@
+package com.lyft.networking.apiObjects;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * A Location model with eta meta data ssociated.
+ */
+public class EtaLocation extends LyftLocation
+{
+    /**
+     * Estimated time for the driver to arrive at the location.
+     * Available after ride status changes to accepted and until arrived.
+     */
+    @SerializedName("eta_seconds")
+    public int eta_seconds;
+
+}

--- a/networking/src/main/java/com/lyft/networking/apiObjects/LyftDriver.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/LyftDriver.java
@@ -1,0 +1,17 @@
+package com.lyft.networking.apiObjects;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Extension of the LyftUser model with
+ * phone number meta data
+ */
+
+public class LyftDriver extends LyftUser
+{
+    /**
+     * Driver phone number
+     */
+    @SerializedName("phone_number")
+    public String phone_number;
+}

--- a/networking/src/main/java/com/lyft/networking/apiObjects/LyftLocation.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/LyftLocation.java
@@ -1,0 +1,26 @@
+package com.lyft.networking.apiObjects;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Model containing information about a Lyft Location.
+ * The model can be used to represent the destination or origin
+ * location of rides on the Lyft Platform.
+ */
+
+public class LyftLocation extends LatLng
+{
+    /**
+     * Display address at/near the given location.
+     */
+    @SerializedName("address")
+    public String address = null;
+    public LyftLocation(){ this(0, 0);}
+    public LyftLocation(double lat, double lng) { this(lat, lng, null); }
+    public LyftLocation(double lat, double lng, String address)
+    {
+        super(lat, lng);
+        this.address = address;
+    }
+
+}

--- a/networking/src/main/java/com/lyft/networking/apiObjects/LyftUser.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/LyftUser.java
@@ -1,0 +1,38 @@
+package com.lyft.networking.apiObjects;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Represents a user object model on the Lyft API.
+ * This object model can be used to represent the base line
+ * information for a driver or a passenger on the Lyft platform
+ */
+public class LyftUser
+{
+    /**
+     * Rating of the user; current rating (0.0 – 5.0).
+     */
+    @SerializedName("rating")
+    public String rating;
+    /**
+     * Id of the user
+     */
+    @SerializedName("user_id")
+    public String user_id;
+    /**
+     * First Name
+     */
+    @SerializedName("first_name")
+    public String first_name;
+    /**
+     * Last Name
+     */
+    @SerializedName("last_name")
+    public String last_name;
+    /**
+     * Profile picture image
+     */
+    @SerializedName("image_url")
+    public String image_url;
+
+}

--- a/networking/src/main/java/com/lyft/networking/apiObjects/MonetaryAmount.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/MonetaryAmount.java
@@ -1,0 +1,22 @@
+package com.lyft.networking.apiObjects;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Model representing monetary amount and currency
+ */
+
+public class MonetaryAmount
+{
+    /**
+     * The monetary amount
+     */
+    @SerializedName("amount")
+    public int amount;
+
+    /**
+     * The ISO 4217 currency code for the amount (e.g. USD).
+     */
+    @SerializedName("currency")
+    public String currency;
+}

--- a/networking/src/main/java/com/lyft/networking/apiObjects/RideCancellation.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/RideCancellation.java
@@ -1,0 +1,22 @@
+package com.lyft.networking.apiObjects;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Created by awaht on 10/4/2017.
+ */
+
+public class RideCancellation extends MonetaryAmount
+{
+    /**
+     * Token used to confirm the fee when cancelling a request.
+     */
+    @SerializedName("token")
+    public String token ;
+
+    /**
+     * How long, in seconds, before the token expires.
+     */
+    @SerializedName("token_duration")
+    public int token_duration ;
+}

--- a/networking/src/main/java/com/lyft/networking/apiObjects/RideHistory.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/RideHistory.java
@@ -1,0 +1,162 @@
+package com.lyft.networking.apiObjects;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * A model for an instance of a user's RideHistory
+ */
+
+public class RideHistory
+{
+    /**
+     * Ride id
+     */
+    @SerializedName("ride_id")
+    public String ride_id;
+    /**
+     * Ride type expressed as one of (lyft, lyft_plus, lyft_line, etc).
+     */
+    @SerializedName("ride_type")
+    public String ride_type;
+    /**
+     * Ride status expressed as one of (pending, accepted, arrived,
+     * pickedUp, droppedOff, canceled, unknown).
+     */
+    @SerializedName("status")
+    public String status;
+
+    /**
+     * Prime Time percentage applied to the base price
+     */
+    @SerializedName("primetime_percentage")
+    public String primetime_percentage;
+
+    /**
+     * The ISO8601 Timestamp of when the request was made.
+     */
+    @SerializedName("requested_at")
+    public String requested_at;
+
+    /**
+     * Indicates whether the ride was requested from the business profile or personal
+     * profile of the passenger.
+     */
+    @SerializedName("ride_profile")
+    public String ride_profile;
+
+    /**
+     * Amp color HEX code, eg. #FFFFFF.
+     */
+    @SerializedName("beacon_color")
+    public String beacon_color;
+
+    /**
+     * Link to a web view showing the pricing structure for the geographic area where
+     * the ride was taken.
+     */
+    @SerializedName("pricing_details_url")
+    public String pricing_details_url;
+
+    /**
+     * Link to a web view showing the passenger, driver, and route information for a ride.
+     * This field will only be present for rides created via the API, or that have been
+     * shared through the "Share my Route" feature.
+     */
+    @SerializedName("route_url")
+    public String route_url;
+
+    /**
+     * The role of user who canceled the ride (if applicable).
+     */
+    @SerializedName("canceled_by")
+    public String canceled_by;
+
+    /**
+     * The written feedback the user left for this ride.
+     */
+    @SerializedName("feedback")
+    public String feedback;
+    /**
+     * The array of actors who may cancel the ride at this point (driver, passenger, dispatcher).
+     */
+    @SerializedName("can_cancel")
+    public String[] can_cancel;
+
+    /**
+     * Actual location of passenger pickup.
+     */
+    @SerializedName("pickup")
+    public LyftLocation pickup;
+
+    /**
+     * Requested location for passenger drop off.
+     */
+    @SerializedName("destination")
+
+    public LyftLocation destination;
+    /**
+     * Actual location of passenger drop off
+    */
+    @SerializedName("dropoff")
+    public LyftLocation dropoff;
+
+    /**
+     * Current location of the vehicle. Available after ride status changes
+     * to pickedUp and until droppedOff.
+     */
+    @SerializedName("location")
+    public LyftLocation location;
+
+    /**
+     * Requested location for passenger pickup.
+     */
+    @SerializedName("origin")
+    public EtaLocation origin;
+
+    /**
+     * The passenger meta data
+     */
+    @SerializedName("passenger")
+    public LyftUser passenger;
+
+    /**
+     * Driver meta data
+     */
+    @SerializedName("driver")
+    public LyftDriver driver;
+    /**
+     * Total cost for the ride. Available after ride status changes to droppedOff and
+     * the passenger has rated and paid for the ride, plus some processing time.
+     */
+    @SerializedName("price")
+    public RidePrice price;
+
+    /**
+     * The cost of cancellation if there would be a penalty
+     */
+    @SerializedName("cancellation_price")
+    public RideCancellation cancellation_price;
+    /**
+     * Vehicle meta data
+     */
+    @SerializedName("vehicle")
+    public Vehicle vehicle;
+
+    @SerializedName("distance_miles")
+    public double distance_miles;
+
+    @SerializedName("duration_seconds")
+    public double duration_seconds;
+
+    @SerializedName("rating")
+    public int rating;
+
+    /**
+     * Helper method that returns a boolean flag indicating whether or not the Ride represented by
+     * this instance of RideHistory is in a pending state.
+     * @return
+     */
+    public boolean isPending() { return "pending".equalsIgnoreCase(status) || "unknown".equalsIgnoreCase(status); }
+
+
+}

--- a/networking/src/main/java/com/lyft/networking/apiObjects/RidePrice.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/RidePrice.java
@@ -1,0 +1,9 @@
+package com.lyft.networking.apiObjects;
+
+/**
+ * Created by awaht on 10/4/2017.
+ */
+
+public class RidePrice
+{
+}

--- a/networking/src/main/java/com/lyft/networking/apiObjects/RideRequest.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/RideRequest.java
@@ -1,0 +1,55 @@
+package com.lyft.networking.apiObjects;
+
+/**
+ * Model containing information necessary to request a
+ * ride on the Lyft Platfrom
+ */
+public class RideRequest
+{
+    /**
+     * Required: Pickup location
+     */
+    public LyftLocation origin;
+
+    /**
+     * Drop off location
+     */
+    public LyftLocation destination;
+
+    /**
+     * Required: Ride type; supported values depend on your location, check
+     * Availability - Ride Types for acceptable values (possible examples
+     * include: lyft, lyft_plus, etc).
+     */
+    public String  ride_type;
+
+    /**
+     * Prime Time Confirmation token
+     * Deprecated, use {@link RideRequest#cost_token} instead.
+     */
+    @Deprecated
+    public String primetime_confirmation_token;
+
+    /**
+     * If Prime Time is active, the response will include a Cost Token under
+     * the key cost_token. It is your application's responsibility to confirm
+     * the user's acceptance of Prime Time pricing. Once the user has accepted
+     * the pricing, your application should repeat the request with the
+     * confirmation token to confirm the ride request. The Cost Token locks in
+     * pricing for one minute. Note that this is the same cost_token that is
+     * also in the Availability - Ride Estimates response when querying that
+     * endpoint with a user context.
+     */
+    public String cost_token;
+
+    public RideRequest(LyftLocation origin, LyftLocation destination, String ride_type) { this(origin, destination, ride_type, null);}
+    public RideRequest(LyftLocation origin, LyftLocation destination, String ride_type, String cost_token)
+    {
+        this.origin         = origin;
+        this.ride_type      = ride_type;
+        this.cost_token     = cost_token;
+        this.destination    = destination;
+
+    }
+
+}

--- a/networking/src/main/java/com/lyft/networking/apiObjects/RideRequestResponse.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/RideRequestResponse.java
@@ -1,0 +1,47 @@
+package com.lyft.networking.apiObjects;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Response model for requests for Rides on the Lyft Platform
+ */
+
+public class RideRequestResponse
+{
+    /**
+     * Requested ride ID.
+     */
+    @SerializedName("ride_id")
+    public String ride_id;
+
+    /**
+     * Ride type will correspond to the ride_type request body parameter.
+     */
+    @SerializedName("ride_type")
+    public String ride_type;
+
+    /**
+     * Ride status for a newly requested ride will be returned as pending.
+     */
+    @SerializedName("status")
+    public String status;
+
+    /**
+     * Requested location for passenger pickup.
+     */
+    @SerializedName("origin")
+    public LyftLocation origin;
+
+    /**
+     * Requested location for passenger drop off.
+     */
+    @SerializedName("destination")
+    public LyftLocation destination;
+
+    /**
+     * The passenger
+     */
+    @SerializedName("passenger")
+    public LyftUser passenger;
+
+}

--- a/networking/src/main/java/com/lyft/networking/apiObjects/UserRideHistoryResponse.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/UserRideHistoryResponse.java
@@ -1,0 +1,16 @@
+package com.lyft.networking.apiObjects;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+/**
+ * Response model for requests for User Ride History on the Lyft Platform
+ */
+
+public class UserRideHistoryResponse
+{
+    @SerializedName("ride_history")
+    public List<RideHistory> ride_history;
+
+}

--- a/networking/src/main/java/com/lyft/networking/apiObjects/Vehicle.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/Vehicle.java
@@ -1,0 +1,53 @@
+package com.lyft.networking.apiObjects;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Model containing vehicle meta data
+ */
+
+public class Vehicle
+{
+    /**
+     * Vehicle year
+     */
+    @SerializedName("year")
+    public int year;
+
+    /**
+     * Vehicle make
+     */
+    @SerializedName("make")
+    public String make;
+
+    /**
+     * Vehicle model
+     */
+    @SerializedName("model")
+    public String model;
+
+    /**
+     * Vehicle license plate
+     */
+    @SerializedName("license_plate")
+    public String license_plate;
+
+    /**
+     * Vehicle license plate state
+     */
+    @SerializedName("license_plate_state")
+    public String license_plate_state;
+
+    /**
+     * Vehicle color
+     */
+    @SerializedName("color")
+    public String color;
+
+    /**
+     * Vehicle image_ur
+     */
+    @SerializedName("image_ur")
+    public String image_url;
+
+}

--- a/networking/src/main/java/com/lyft/networking/apis/LyftPublicApi.java
+++ b/networking/src/main/java/com/lyft/networking/apis/LyftPublicApi.java
@@ -65,7 +65,7 @@ public interface LyftPublicApi {
      * specified location
      * @param lat               Pick up location latitude
      * @param lng               Pick up location longitude
-     * @param ride_type         The id of the desired ride type that driver eta is
+     * @param rideType          The id of the desired ride type that driver eta is
      *                          being requested for.
      * @param destination_lat   Destination location latitude
      * @param destination_lng   Destination location longitude

--- a/networking/src/main/java/com/lyft/networking/apis/LyftPublicApi.java
+++ b/networking/src/main/java/com/lyft/networking/apis/LyftPublicApi.java
@@ -37,6 +37,17 @@ public interface LyftPublicApi {
     @GET("/v1/drivers")
     Call<NearbyDriversResponse> getDrivers(@Query("lat") Double lat, @Query("lng") Double lng);
 
+    /***
+     * Returns the estimated time in seconds it will take for the nearest driver to reach the
+     * specified location
+     * @param lat   Pick up location latitude
+     * @param lng   Pick up location longitude
+     * @return Retrofit Call of {@link EtaEstimateResponse} type.
+     */
+    @GET("/v1/eta")
+    Call<EtaEstimateResponse> getEtas(@Query("lat") double lat, @Query("lng") double lng);
+
+
     /**
     * Pickup ETAs
     * The ETA endpoint lets you know how quickly a Lyft driver can come get you 
@@ -48,6 +59,20 @@ public interface LyftPublicApi {
     
     @GET("/v1/eta")
     Call<EtaEstimateResponse> getEtas(@Query("lat") Double lat, @Query("lng") Double lng, @Query("ride_type") String rideType);
+
+    /***
+     * Returns the estimated time in seconds it will take for the nearest driver to reach the
+     * specified location
+     * @param lat               Pick up location latitude
+     * @param lng               Pick up location longitude
+     * @param ride_type         The id of the desired ride type that driver eta is
+     *                          being requested for.
+     * @param destination_lat   Destination location latitude
+     * @param destination_lng   Destination location longitude
+     * @return Retrofit Call of {@link EtaEstimateResponse} type.
+     */
+    @GET("/v1/eta")
+    Call<EtaEstimateResponse> getEtas(@Query("lat") double lat, @Query("lng") double lng, @Query("ride_type") String ride_type, @Query("destination_lat") Double destination_lat, @Query("destination_lng") Double destination_lng);
 
     /**
     * Types of rides

--- a/networking/src/main/java/com/lyft/networking/apis/LyftPublicApi.java
+++ b/networking/src/main/java/com/lyft/networking/apis/LyftPublicApi.java
@@ -72,7 +72,7 @@ public interface LyftPublicApi {
      * @return Retrofit Call of {@link EtaEstimateResponse} type.
      */
     @GET("/v1/eta")
-    Call<EtaEstimateResponse> getEtas(@Query("lat") double lat, @Query("lng") double lng, @Query("ride_type") String ride_type, @Query("destination_lat") Double destination_lat, @Query("destination_lng") Double destination_lng);
+    Call<EtaEstimateResponse> getEtas(@Query("lat") double lat, @Query("lng") double lng, @Query("ride_type") String rideType, @Query("destination_lat") Double destination_lat, @Query("destination_lng") Double destination_lng);
 
     /**
     * Types of rides

--- a/networking/src/main/java/com/lyft/networking/apis/LyftUserApi.java
+++ b/networking/src/main/java/com/lyft/networking/apis/LyftUserApi.java
@@ -1,0 +1,152 @@
+package com.lyft.networking.apis;
+
+import com.lyft.networking.ApiConfig;
+import com.lyft.networking.apiObjects.EtaEstimateResponse;
+import com.lyft.networking.apiObjects.RideRequest;
+import com.lyft.networking.apiObjects.RideRequestResponse;
+import com.lyft.networking.apiObjects.UserRideHistoryResponse;
+
+import okhttp3.ResponseBody;
+import retrofit2.Call;
+import retrofit2.http.Body;
+import retrofit2.http.GET;
+import retrofit2.http.POST;
+import retrofit2.http.Path;
+import retrofit2.http.Query;
+
+/**
+ * Retrofit API interface for requests made on behalf of the user on the Lyft Platform.
+ * Important note: every method in this interface requires the call to be made with an
+ * actual oAuth access_token for the user. Your application would have needed to go through
+ * the 3-legged oAuth process flow to acquire the access_token from the user. With the
+ * access token in hand you can call the {@link ApiConfig#setUserAccessToken(String)} method
+ * to set the user's access token prior to making any calls from a Retrofit Api class built
+ * from this interface. For more information on how to acquire the user access token, and the
+ * 3-legged oAuth process flow, see {@link "https://developer.lyft.com/v1/docs/authentication"}
+ */
+
+public interface LyftUserApi
+{
+    /**
+     * Request a ride on behalf of the user. The user's payment credentials
+     * on file will be charged for the ride.
+     * @param rideRequest Details about the ride being requested
+     * @return Retrofit Call of {@link RideRequestResponse} type.
+     */
+    @POST("/v1/rides")
+    Call<RideRequestResponse> requestRide(@Body RideRequest rideRequest);
+
+    /***
+     * Cancels a specified ride on behalf of a user.
+     * @param ride_id   The Id of the ride to cancel
+     * @return Retrofit Call of {@link ResponseBody} type. In some cases, there may be a
+     * cancellation fee — which the user must pay — in order to cancel the ride. If there
+     * is a cancellation fee the call to this method will result in an HTTP-400 response with
+     * the response body containing error description meta data (in the form of JSON). The returned
+     * error meta data will include a token, which is valid for token_duration seconds.
+     *
+     * Using this token, it is your application's responsibility to confirm the user's acceptance
+     * of the cancellation fee. Once the user has accepted the fee, your application should repeat
+     * the request with the cancel_confirmation_token by using the method call {@link LyftUserApi#cancelRide(String, String)}
+     */
+    @POST("/v1/rides/{ride_id}/cancel")
+    Call<ResponseBody> cancelRide(@Path("ride_id") String ride_id);
+
+    /***
+     * Cancels a specified ride on behalf of a user (with the use of a
+     * cancellation confirmation token). For more information about cancellation
+     * confirmation tokens see {@link LyftUserApi#cancelRide(String)} and {@link "https://developer.lyft.com/reference#ride-request-cancel"}
+     * @param ride_id                   The Id of the ride to cancel
+     * @param cancel_confirmation_token Cancellation confirmation token
+     * @return Retrofit Call of {@link ResponseBody} type.
+     */
+    @POST("/v1/rides/{ride_id}/cancel")
+    Call<ResponseBody> cancelRide(@Path("ride_id") String ride_id, @Body String cancel_confirmation_token);
+
+    /***
+     * Returns the estimated time in seconds it will take for the nearest driver to reach the
+     * specified location
+     * @param lat   Pick up location latitude
+     * @param lng   Pick up location longitude
+     * @return Retrofit Call of {@link EtaEstimateResponse} type.
+     */
+    @GET("/v1/eta")
+    Call<EtaEstimateResponse> getEtas(@Query("lat") double lat, @Query("lng") double lng);
+
+
+    /***
+     * Returns the estimated time in seconds it will take for the nearest driver to reach the
+     * specified location
+     * @param lat       Pick up location latitude
+     * @param lng       Pick up location longitude
+     * @param ride_type The id of the desired ride type that driver eta is being requested for.
+     * @return Retrofit Call of {@link EtaEstimateResponse} type.
+     */
+    @GET("/v1/eta")
+    Call<EtaEstimateResponse> getEtas(@Query("lat") double lat, @Query("lng") double lng, @Query("ride_type") String ride_type);
+
+    /***
+     * Returns the estimated time in seconds it will take for the nearest driver to reach the
+     * specified location
+     * @param lat               Pick up location latitude
+     * @param lng               Pick up location longitude
+     * @param ride_type         The id of the desired ride type that driver eta is
+     *                          being requested for.
+     * @param destination_lat   Destination location latitude
+     * @param destination_lng   Destination location longitude
+     * @return Retrofit Call of {@link EtaEstimateResponse} type.
+     */
+    @GET("/v1/eta")
+    Call<EtaEstimateResponse> getEtas(@Query("lat") double lat, @Query("lng") double lng, @Query("ride_type") String ride_type, @Query("destination_lat") Double destination_lat, @Query("destination_lng") Double destination_lng);
+
+    /***
+     * Returns a list of current and past rides for a given, authenticated passenger. If there's
+     * a ride in progress, location will have the ride's current location.
+     * This method overload will return no more than 10 rides from the user's ride history.
+     * If more than 10 rides are required, please use {@link LyftUserApi#getUserRideHistory(String, int)}
+     * @param start_time The ISO8601 start time to filter rides.
+     *                   The earliest supported date is 2015-01-01T00:00:00Z
+     * @return Retrofit Call of {@link UserRideHistoryResponse} type.
+     */
+    @GET("/v1/rides")
+    Call<UserRideHistoryResponse> getUserRideHistory(@Query("start_time") String start_time);
+
+    /***
+     * Returns a list of current and past rides for a given, authenticated passenger. If there's
+     * a ride in progress, location will have the ride's current location.
+     * @param start_time    The ISO8601 start time to filter rides.
+     *                      The earliest supported date is 2015-01-01T00:00:00Z
+     * @param limit         The Maximum number of rides to return. The maximum possible value is 50
+     * @return Retrofit Call of {@link UserRideHistoryResponse} type.
+     */
+    @GET("/v1/rides")
+    Call<UserRideHistoryResponse> getUserRideHistory(@Query("start_time") String start_time, @Query("limit") int limit);
+
+    /***
+     * Returns a list of current and past rides for a given, authenticated passenger. If there's
+     * a ride in progress, location will have the ride's current location.
+     * This method overload will return no more than 10 rides from the user's ride history.
+     * If more than 10 rides are required, please use {@link LyftUserApi#getUserRideHistory(String, String, int)}
+     * @param start_time    The ISO8601 start time to filter rides.
+     *                      The earliest supported date is 2015-01-01T00:00:00Z
+     * @param end_time      The ISO8601 end time to filter rides.
+     *                      The earliest supported date is 2015-01-01T00:00:00Z
+     * @return Retrofit Call of {@link UserRideHistoryResponse} type.
+     */
+    @GET("/v1/rides")
+    Call<UserRideHistoryResponse> getUserRideHistory(@Query("start_time") String start_time, @Query("end_time") String end_time );
+
+    /***
+     * Returns a list of current and past rides for a given, authenticated passenger. If there's
+     * a ride in progress, location will have the ride's current location.
+     * @param start_time    The ISO8601 start time to filter rides.
+     *                      The earliest supported date is 2015-01-01T00:00:00Z
+     * @param end_time      The ISO8601 end time to filter rides.
+     *                      The earliest supported date is 2015-01-01T00:00:00Z
+     * @param limit         The Maximum number of rides to return. The maximum possible value is 50
+     * @return Retrofit Call of {@link UserRideHistoryResponse} type.
+     */
+    @GET("/v1/rides")
+    Call<UserRideHistoryResponse> getUserRideHistory(@Query("start_time") String start_time, @Query("end_time") String end_time, @Query("limit") int limit);
+
+}

--- a/networking/src/main/java/com/lyft/networking/apis/LyftUserApiRx.java
+++ b/networking/src/main/java/com/lyft/networking/apis/LyftUserApiRx.java
@@ -1,0 +1,154 @@
+package com.lyft.networking.apis;
+
+import com.lyft.networking.ApiConfig;
+import com.lyft.networking.apiObjects.RideRequest;
+import com.lyft.networking.apiObjects.RideRequestResponse;
+import com.lyft.networking.apiObjects.UserRideHistoryResponse;
+
+import okhttp3.ResponseBody;
+import retrofit2.http.Body;
+import retrofit2.http.GET;
+import retrofit2.http.POST;
+import retrofit2.http.Path;
+import retrofit2.http.Query;
+import rx.Observable;
+
+/**
+ * Retrofit API interface for requests made on behalf of the user on the Lyft Platform.
+ * Important note: every method in this interface requires the call to be made with an
+ * actual oAuth access_token for the user. Your application would have needed to go through
+ * the 3-legged oAuth process flow to acquire the access_token from the user. With the
+ * access token in hand you can call the {@link ApiConfig#setUserAccessToken(String)} method
+ * to set the user's access token prior to making any calls from a Retrofit Api class built
+ * from this interface. For more information on how to acquire the user access token, and the
+ * 3-legged oAuth process flow, see {@link "https://developer.lyft.com/v1/docs/authentication"}
+ */
+
+public interface LyftUserApiRx
+{
+    /**
+     * Request a ride on behalf of the user. The user's payment credentials
+     * on file will be charged for the ride.
+     * @param rideRequest Details about the ride being requested
+     * @return Retrofit Call of {@link RideRequestResponse} type.
+     */
+    @POST("/v1/rides")
+    Observable<RideRequestResponse> requestRide(@Body RideRequest rideRequest);
+
+    /***
+     * Cancels a specified ride on behalf of a user.
+     * @param ride_id   The Id of the ride to cancel
+     * @return Retrofit Call of {@link ResponseBody} type. In some cases, there may be a
+     * cancellation fee — which the user must pay — in order to cancel the ride. If there
+     * is a cancellation fee the call to this method will result in an HTTP-400 response with
+     * the response body containing error description meta data (in the form of JSON). The returned
+     * error meta data will include a token, which is valid for token_duration seconds.
+     *
+     * Using this token, it is your application's responsibility to confirm the user's acceptance
+     * of the cancellation fee. Once the user has accepted the fee, your application should repeat
+     * the request with the cancel_confirmation_token by using the method call {@link LyftUserApiRx#cancelRide(String, String)}
+     *
+     */
+    @POST("/v1/rides/{ride_id}/cancel")
+    Observable<ResponseBody> cancelRide(@Path("ride_id") String ride_id);
+
+    /***
+     * Cancels a specified ride on behalf of a user (with the use of a
+     * cancellation confirmation token). For more information about cancellation
+     * confirmation tokens see {@link LyftUserApiRx#cancelRide(String)} and {@link "https://developer.lyft.com/reference#ride-request-cancel"}
+     * @param ride_id                   The Id of the ride to cancel
+     * @param cancel_confirmation_token Cancellation confirmation token
+     * @return Retrofit Call of {@link ResponseBody} type.
+     */
+    @POST("/v1/rides/{ride_id}/cancel")
+    Observable<ResponseBody> cancelRide(@Path("ride_id") String ride_id, @Body String cancel_confirmation_token);
+
+    /***
+     * Returns the estimated time in seconds it will take for the nearest driver to reach the
+     * specified location
+     * @param lat   Pick up location latitude
+     * @param lng   Pick up location longitude
+     * @return Retrofit Call of {@link DriverEtaResponse} type.
+     */
+    @GET("/v1/eta")
+    Observable<DriverEtaResponse> getDriverETA(@Query("lat") double lat, @Query("lng") double lng);
+
+    /***
+     * Returns the estimated time in seconds it will take for the nearest driver to reach the
+     * specified location
+     * @param lat               Pick up location latitude
+     * @param lng               Pick up location longitude
+     * @param ride_type         The id of the desired ride type that driver eta is
+     *                          being requested for.
+     * @param destination_lat   Destination location latitude
+     * @param destination_lng   Destination location longitude
+     * @return Retrofit Call of {@link DriverEtaResponse} type.
+     */
+    @GET("/v1/eta")
+    Observable<DriverEtaResponse> getDriverETA(@Query("lat") double lat, @Query("lng") double lng,
+                                         @Query("ride_type") String ride_type, @Query
+                                                 ("destination_lat") double destination_lat,
+                                         @Query("destination_lng") String destination_lng);
+
+    /***
+     * Returns the estimated time in seconds it will take for the nearest driver to reach the
+     * specified location
+     * @param lat       Pick up location latitude
+     * @param lng       Pick up location longitude
+     * @param ride_type The id of the desired ride type that driver eta is being requested for.
+     * @return Retrofit Call of {@link DriverEtaResponse} type.
+     */
+    @GET("/v1/eta")
+    Observable<DriverEtaResponse> getDriverETA(@Query("lat") double lat, @Query("lng") double lng, @Query("ride_type") String ride_type);
+
+    /***
+     * Returns a list of current and past rides for a given, authenticated passenger. If there's
+     * a ride in progress, location will have the ride's current location.
+     * This method overload will return no more than 10 rides from the user's ride history.
+     * If more than 10 rides are required, please use {@link LyftUserApiRx#getUserRideHistory(String, int)}
+     * @param start_time The ISO8601 start time to filter rides.
+     *                   The earliest supported date is 2015-01-01T00:00:00Z
+     * @return Retrofit Call of {@link UserRideHistoryResponse} type.
+     */
+    @GET("/v1/rides")
+    Observable<UserRideHistoryResponse> getUserRideHistory(@Query("start_time") String start_time);
+
+    /***
+     * Returns a list of current and past rides for a given, authenticated passenger. If there's
+     * a ride in progress, location will have the ride's current location.
+     * @param start_time    The ISO8601 start time to filter rides.
+     *                      The earliest supported date is 2015-01-01T00:00:00Z
+     * @param limit         The Maximum number of rides to return. The maximum possible value is 50
+     * @return Retrofit Call of {@link UserRideHistoryResponse} type.
+     */
+    @GET("/v1/rides")
+    Observable<UserRideHistoryResponse> getUserRideHistory(@Query("start_time") String start_time, @Query("limit") int limit);
+
+    /***
+     * Returns a list of current and past rides for a given, authenticated passenger. If there's
+     * a ride in progress, location will have the ride's current location.
+     * This method overload will return no more than 10 rides from the user's ride history.
+     * If more than 10 rides are required, please use {@link LyftUserApiRx#getUserRideHistory(String, String, int)}
+     * @param start_time    The ISO8601 start time to filter rides.
+     *                      The earliest supported date is 2015-01-01T00:00:00Z
+     * @param end_time      The ISO8601 end time to filter rides.
+     *                      The earliest supported date is 2015-01-01T00:00:00Z
+     * @return Retrofit Call of {@link UserRideHistoryResponse} type.
+     */
+    @GET("/v1/rides")
+    Observable<UserRideHistoryResponse> getUserRideHistory(@Query("start_time") String start_time, @Query("end_time") String end_time);
+
+    /***
+     * Returns a list of current and past rides for a given, authenticated passenger. If there's
+     * a ride in progress, location will have the ride's current location.
+     * @param start_time    The ISO8601 start time to filter rides.
+     *                      The earliest supported date is 2015-01-01T00:00:00Z
+     * @param end_time      The ISO8601 end time to filter rides.
+     *                      The earliest supported date is 2015-01-01T00:00:00Z
+     * @param limit         The Maximum number of rides to return. The maximum possible value is 50
+     * @return Retrofit Call of {@link UserRideHistoryResponse} type.
+     */
+    @GET("/v1/rides")
+    Observable<UserRideHistoryResponse> getUserRideHistory(@Query("start_time") String start_time, @Query("end_time") String end_time, @Query("limit") int limit);
+
+}

--- a/networking/src/main/java/com/lyft/networking/apis/LyftUserApiRx.java
+++ b/networking/src/main/java/com/lyft/networking/apis/LyftUserApiRx.java
@@ -1,6 +1,7 @@
 package com.lyft.networking.apis;
 
 import com.lyft.networking.ApiConfig;
+import com.lyft.networking.apiObjects.EtaEstimateResponse;
 import com.lyft.networking.apiObjects.RideRequest;
 import com.lyft.networking.apiObjects.RideRequestResponse;
 import com.lyft.networking.apiObjects.UserRideHistoryResponse;
@@ -68,10 +69,10 @@ public interface LyftUserApiRx
      * specified location
      * @param lat   Pick up location latitude
      * @param lng   Pick up location longitude
-     * @return Retrofit Call of {@link DriverEtaResponse} type.
+     * @return Retrofit Call of {@link EtaEstimateResponse} type.
      */
     @GET("/v1/eta")
-    Observable<DriverEtaResponse> getDriverETA(@Query("lat") double lat, @Query("lng") double lng);
+    Observable<EtaEstimateResponse> getEtas(@Query("lat") double lat, @Query("lng") double lng);
 
     /***
      * Returns the estimated time in seconds it will take for the nearest driver to reach the
@@ -82,10 +83,10 @@ public interface LyftUserApiRx
      *                          being requested for.
      * @param destination_lat   Destination location latitude
      * @param destination_lng   Destination location longitude
-     * @return Retrofit Call of {@link DriverEtaResponse} type.
+     * @return Retrofit Call of {@link EtaEstimateResponse} type.
      */
     @GET("/v1/eta")
-    Observable<DriverEtaResponse> getDriverETA(@Query("lat") double lat, @Query("lng") double lng,
+    Observable<EtaEstimateResponse> getEtas(@Query("lat") double lat, @Query("lng") double lng,
                                          @Query("ride_type") String ride_type, @Query
                                                  ("destination_lat") double destination_lat,
                                          @Query("destination_lng") String destination_lng);
@@ -96,10 +97,10 @@ public interface LyftUserApiRx
      * @param lat       Pick up location latitude
      * @param lng       Pick up location longitude
      * @param ride_type The id of the desired ride type that driver eta is being requested for.
-     * @return Retrofit Call of {@link DriverEtaResponse} type.
+     * @return Retrofit Call of {@link EtaEstimateResponse} type.
      */
     @GET("/v1/eta")
-    Observable<DriverEtaResponse> getDriverETA(@Query("lat") double lat, @Query("lng") double lng, @Query("ride_type") String ride_type);
+    Observable<EtaEstimateResponse> getEtas(@Query("lat") double lat, @Query("lng") double lng, @Query("ride_type") String ride_type);
 
     /***
      * Returns a list of current and past rides for a given, authenticated passenger. If there's

--- a/test-utils/src/main/java/com/lyft/testutils/MockLyftPublicApi.java
+++ b/test-utils/src/main/java/com/lyft/testutils/MockLyftPublicApi.java
@@ -19,6 +19,9 @@ public class MockLyftPublicApi implements LyftPublicApi {
     private static final String LYFT_LINE = "lyft_line";
     private static final String LYFT = "lyft";
     private static final String LYFT_PLUS = "lyft_plus";
+    private static final String LYFT_PREMIER = "lyft_premier";
+    private static final String LYFT_LUX = "lyft_lux";
+    private static final String LYFT_LUX_SUV = "lyft_luxsuv";
 
     private final BehaviorDelegate<LyftPublicApi> delegate;
     private CostEstimateResponse costEstimateResponse;
@@ -32,13 +35,16 @@ public class MockLyftPublicApi implements LyftPublicApi {
 
     @Override
     public Call<CostEstimateResponse> getCosts(@Query("start_lat") Double startLat, @Query("start_lng") Double startLng,
-            @Query("ride_type") String rideType, @Query("end_lat") Double endLat, @Query("end_lng") Double endLng) {
+                                               @Query("ride_type") String rideType, @Query("end_lat") Double endLat, @Query("end_lng") Double endLng) {
         if (!useCustomCostResponse) {
             List<CostEstimate> costEstimates = new ArrayList<>();
             if (rideType == null) {
                 costEstimates.add(createCostEstimateForRideType(LYFT_LINE));
                 costEstimates.add(createCostEstimateForRideType(LYFT));
                 costEstimates.add(createCostEstimateForRideType(LYFT_PLUS));
+                costEstimates.add(createCostEstimateForRideType(LYFT_PREMIER));
+                costEstimates.add(createCostEstimateForRideType(LYFT_LUX));
+                costEstimates.add(createCostEstimateForRideType(LYFT_LUX_SUV));
             } else if (isValidRideType(rideType)) {
                 costEstimates.add(createCostEstimateForRideType(rideType));
             }
@@ -74,12 +80,15 @@ public class MockLyftPublicApi implements LyftPublicApi {
 
     @Override
     public Call<RideTypesResponse> getRidetypes(@Query("lat") Double lat, @Query("lng") Double lng,
-            @Query("ride_type") String rideType) {
+                                                @Query("ride_type") String rideType) {
         List<RideType> rideTypes = new ArrayList<>();
         if (rideType == null) {
             rideTypes.add(new RideType(LYFT_LINE, getDisplayNameForRideType(LYFT_LINE), 4, null, null, null));
             rideTypes.add(new RideType(LYFT, getDisplayNameForRideType(LYFT), 4, null, null, null));
             rideTypes.add(new RideType(LYFT_PLUS, getDisplayNameForRideType(LYFT_PLUS), 6, null, null, null));
+            rideTypes.add(new RideType(LYFT_PREMIER, getDisplayNameForRideType(LYFT_PREMIER), 4, null, null, null));
+            rideTypes.add(new RideType(LYFT_LUX, getDisplayNameForRideType(LYFT_LUX), 4, null, null, null));
+            rideTypes.add(new RideType(LYFT_LUX_SUV, getDisplayNameForRideType(LYFT_LUX_SUV), 6, null, null, null));
         } else {
             rideTypes.add(new RideType(rideType, getDisplayNameForRideType(rideType), 6, null, null, null));
         }
@@ -98,13 +107,16 @@ public class MockLyftPublicApi implements LyftPublicApi {
     }
 
     private static CostEstimate createCostEstimateForRideType(String rideType) {
-        return new CostEstimate(rideType, getDisplayNameForRideType(rideType), "USD", null, null, null, null, null, null);
+        return new CostEstimate(rideType, getDisplayNameForRideType(rideType), "USD", null, null, null, null, null, null, null);
     }
 
     private static boolean isValidRideType(String rideType) {
         return LYFT_LINE.equals(rideType)
                 || LYFT.equals(rideType)
-                || LYFT_PLUS.equals(rideType);
+                || LYFT_PLUS.equals(rideType)
+                || LYFT_PREMIER.equals(rideType)
+                || LYFT_LUX.equals(rideType)
+                || LYFT_LUX_SUV.equals(rideType);
     }
 
     private static String getDisplayNameForRideType(String rideType) {
@@ -114,6 +126,18 @@ public class MockLyftPublicApi implements LyftPublicApi {
 
         if (LYFT_PLUS.equals(rideType)) {
             return "Lyft Plus";
+        }
+
+        if(LYFT_PREMIER.equals(rideType)) {
+            return "Lyft Premier";
+        }
+
+        if(LYFT_LUX.equals(rideType)) {
+            return "Lyft Lux";
+        }
+
+        if(LYFT_LUX_SUV.equals(rideType)) {
+            return "Lyft Lux SUV";
         }
 
         return "Lyft";

--- a/test-utils/src/main/java/com/lyft/testutils/MockLyftPublicApi.java
+++ b/test-utils/src/main/java/com/lyft/testutils/MockLyftPublicApi.java
@@ -14,7 +14,8 @@ import retrofit2.Call;
 import retrofit2.http.Query;
 import retrofit2.mock.BehaviorDelegate;
 
-public class MockLyftPublicApi implements LyftPublicApi {
+public class MockLyftPublicApi implements LyftPublicApi
+{
 
     private static final String LYFT_LINE = "lyft_line";
     private static final String LYFT = "lyft";
@@ -61,6 +62,12 @@ public class MockLyftPublicApi implements LyftPublicApi {
     }
 
     @Override
+    public Call<EtaEstimateResponse> getEtas(@Query("lat") double lat, @Query("lng") double lng)
+    {
+        return getEtas(lat,lng, null);
+    }
+
+    @Override
     public Call<EtaEstimateResponse> getEtas(@Query("lat") Double lat, @Query("lng") Double lng, @Query("ride_type") String rideType) {
         if (!useCustomEtaResponse) {
             List<Eta> etas = new ArrayList<>();
@@ -68,7 +75,36 @@ public class MockLyftPublicApi implements LyftPublicApi {
                 etas.add(new Eta(LYFT_LINE, getDisplayNameForRideType(LYFT_LINE), 180));
                 etas.add(new Eta(LYFT, getDisplayNameForRideType(LYFT), 60));
                 etas.add(new Eta(LYFT_PLUS, getDisplayNameForRideType(LYFT_PLUS), 300));
+                etas.add(new Eta(LYFT_PREMIER, getDisplayNameForRideType(LYFT_PREMIER), 90));
+                etas.add(new Eta(LYFT_LUX, getDisplayNameForRideType(LYFT_LUX), 30));
+                etas.add(new Eta(LYFT_LUX_SUV, getDisplayNameForRideType(LYFT_LUX_SUV), 180));
             } else if (isValidRideType(rideType)) {
+                etas.add(new Eta(rideType, getDisplayNameForRideType(rideType), 60));
+            }
+
+            etaEstimateResponse = new EtaEstimateResponse(etas);
+        }
+
+        return delegate.returningResponse(etaEstimateResponse).getEtas(lat, lng, rideType);
+    }
+
+    @Override
+    public Call<EtaEstimateResponse> getEtas(@Query("lat") double lat, @Query("lng") double lng, @Query("ride_type") String rideType, @Query("destination_lat") Double destination_lat, @Query("destination_lng") Double destination_lng)
+    {
+        if (!useCustomEtaResponse)
+        {
+            List<Eta> etas = new ArrayList<>();
+            if (rideType == null)
+            {
+                etas.add(new Eta(LYFT_LINE, getDisplayNameForRideType(LYFT_LINE), 180));
+                etas.add(new Eta(LYFT, getDisplayNameForRideType(LYFT), 60));
+                etas.add(new Eta(LYFT_PLUS, getDisplayNameForRideType(LYFT_PLUS), 300));
+                etas.add(new Eta(LYFT_PREMIER, getDisplayNameForRideType(LYFT_PREMIER), 90));
+                etas.add(new Eta(LYFT_LUX, getDisplayNameForRideType(LYFT_LUX), 30));
+                etas.add(new Eta(LYFT_LUX_SUV, getDisplayNameForRideType(LYFT_LUX_SUV), 180));
+            }
+            else if (isValidRideType(rideType))
+            {
                 etas.add(new Eta(rideType, getDisplayNameForRideType(rideType), 60));
             }
 


### PR DESCRIPTION
This PR covers a fix for an issue reported early October on the Lyft developer community forum. Here is the link to the issue:
https://devcommunity.lyft.co/t/discrepancy-in-costestimate-model-for-current-android-sdk-v1-0-3/202

The commit that actually has this fix is [bcde284](https://github.com/awahnteh/lyft-android-sdk/commit/bcde2841ec80cca459f6e2ec646e96488f95aee9). 

In addition to the aforementioned fix, I have filled a few more gaps that were in the SDK, for example:

1.  The SDK in general (and in particular, the MockLyftPublicApi) is now aware of 3 additional Lyft Products which I think were added as products since the last time this SDK was updated in February (see commits [7c61fee](https://github.com/awahnteh/lyft-android-sdk/commit/7c61fee41f9f770e5d22fb088dabf3bbf5c6699b) and [bbe009e](https://github.com/awahnteh/lyft-android-sdk/commit/bbe009e093fedea532a7b033d882014b8dcbad2b).): 

    - `LYFT_PREMIER`, 
    - `LYFT_LUX`, 
    - `LYFT_LUX_SUV` 

2. Added several more model types to the SDK for objects received and returned by the API; some of which are polymorphic (See `EtaLocation` which extends `LyftLocation` and `LyftDriver` which extends `LyftUser` classes as examples). Other examples of models added include (but are not limited to) to (see commit: [395d14d](https://github.com/awahnteh/lyft-android-sdk/commit/395d14dba6aa48885d8113975bb571db432d8c34) ): 
    - `MonetaryAmount`, 
    - `RideHistory`, 
    - `RideRequest`, 
    - `RideRequestResponse` 

3. Added `LyftUserApi` and and `LyftUserApiRx`, which is distinct from the `LyftPublicApi` and `LyftPublicApiRx` interface as in it exposes methods that require an access_token from a user -- whereas the LyftPublicApi exposes methods that do not require a user access_token (see commit: [395d14d](https://github.com/awahnteh/lyft-android-sdk/commit/395d14dba6aa48885d8113975bb571db432d8c34).). In the same context, I have also modified `ApiConfig` and `LyftApiFactory` and abstracted them in such a way that a user can request for a LyftUserApi retrofit client or a LyftPublicApi retrofit client seamlessly. In fact the underlying mechanics that differentiates between a User Api and Public Api retrofit client is the fact that `LyftApiFactory` will create an `OkHttpClient` with a `RequestInterceptor` that passes either the client token via `apiConfig#getClientToken()` (as is the case with a `LyftPublicApi`) or the `LyftApiFactory` will create an `OkHttpClient` with a `RequestInterceptor` that passes either the user access token via: `apiConfig#getUserAccessToken()` . For more details see commit: [395d14d](https://github.com/awahnteh/lyft-android-sdk/commit/395d14dba6aa48885d8113975bb571db432d8c34):

    - `LyftApiFactory.java`: line 27 (for Public Api)
    - `LyftApiFactory.java`: line 37 (for Public Api)
    - `LyftApiFactory.java`: line 72 (for Public Api)
    - `LyftApiFactory.java`: line 78-85 (for User Api)
    - `ApiConfig.java`: line 7 (for User Api)
    - `ApiConfig.java`: line 27-37 (for User Api)
    - `LyftApiFactory.java`: line 43-64 (for User Api)
    - `LyftApiFactory.java`: line 78-85 (for User Api)

4. Exposed overloads to the getEtas method in the LyftPublicApi interface. Effectively exposing a way for users of the SDK to make calls to the getEtas end point without the need to pass parameters that are deemed optional by that endpoint. (see commit: [25fd37e](https://github.com/awahnteh/lyft-android-sdk/commit/25fd37ec98df90799486bcf1313bb44907b6dbde).)

Will Love to get your thoughts and feedback.

Awah T-