### PR TITLE
[Networking] Check and reject responses returned with partial data

### DIFF
--- a/networking/src/main/java/com/lyft/networking/LyftApiFactory.java
+++ b/networking/src/main/java/com/lyft/networking/LyftApiFactory.java
@@ -22,20 +22,58 @@ public class LyftApiFactory {
     /**
      * @return An implementation of Lyft's Public API endpoints that do not require a user.
      * The return type of API calls will be {@link retrofit2.Call}. Used by the LyftButton.
+     *
+     * By default, the Retrofit client will throw a {@link com.lyft.networking.exceptions.PartialResponseException}
+     * if the response returned by the server has missing information (i.e. non-null values returned as null).
+     * To explicitly disallow this, invoke #getLyftPublicApi(boolean).
+     *
      * See: <a href="http://petstore.swagger.io/?url=https://api.lyft.com/v1/spec#!/Public/">http://petstore.swagger.io/?url=https://api.lyft.com/v1/spec#!/Public/</a>
      */
     public LyftPublicApi getLyftPublicApi() {
-        Retrofit retrofitPublicApi = getRetrofitBuilder(getPublicOkHttpClient()).build();
+        return getLyftPublicApi(true);
+    }
+
+    /**
+     * @param requiresCompleteResponse A boolean flag to indicate whether an exception should be thrown
+     *                                 if the server returns partial data. If set true,
+     *                                 the Retrofit client will throw a {@link com.lyft.networking.exceptions.PartialResponseException}
+     *                                 when the response returned by the server has missing information (i.e. non-null values returned as null).
+     * @return An implementation of Lyft's Public API endpoints that do not require a user.
+     * The return type of API calls will be {@link retrofit2.Call}. Used by the LyftButton.
+     *
+     * See: <a href="http://petstore.swagger.io/?url=https://api.lyft.com/v1/spec#!/Public/">http://petstore.swagger.io/?url=https://api.lyft.com/v1/spec#!/Public/</a>
+     */
+    public LyftPublicApi getLyftPublicApi(boolean requiresCompleteResponse) {
+        Retrofit retrofitPublicApi = getRetrofitBuilder(getPublicOkHttpClient(), requiresCompleteResponse).build();
         return retrofitPublicApi.create(LyftPublicApi.class);
     }
 
     /**
      * @return An implementation of Lyft's Public API endpoints that do not require a user.
      * The return type of API calls will be {@link rx.Observable}.
+     *
+     * By default, the Retrofit client will throw a {@link com.lyft.networking.exceptions.PartialResponseException}
+     * if the response returned by the server has missing information (i.e. non-null values returned as null).
+     * To explicitly disallow this, invoke #getLyftPublicApiRx(boolean).
+     *
      * See: <a href="http://petstore.swagger.io/?url=https://api.lyft.com/v1/spec#!/Public/">http://petstore.swagger.io/?url=https://api.lyft.com/v1/spec#!/Public/</a>
      */
     public LyftPublicApiRx getLyftPublicApiRx() {
-        Retrofit retrofitPublicApi = getRetrofitBuilder(getPublicOkHttpClient())
+        return getLyftPublicApiRx(true);
+    }
+
+    /**
+     * @param requiresCompleteResponse A boolean flag to indicate whether an exception should be thrown
+     *                                 if the server returns partial data. If set true,
+     *                                 the Retrofit client will throw a {@link com.lyft.networking.exceptions.PartialResponseException}
+     *                                 when the response returned by the server has missing information (i.e. non-null values returned as null).
+     * @return An implementation of Lyft's Public API endpoints that do not require a user.
+     * The return type of API calls will be {@link rx.Observable}.
+     *
+     * See: <a href="http://petstore.swagger.io/?url=https://api.lyft.com/v1/spec#!/Public/">http://petstore.swagger.io/?url=https://api.lyft.com/v1/spec#!/Public/</a>
+     */
+    public LyftPublicApiRx getLyftPublicApiRx(boolean requiresCompleteResponse) {
+        Retrofit retrofitPublicApi = getRetrofitBuilder(getPublicOkHttpClient(), requiresCompleteResponse)
                 .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
                 .build();
         return retrofitPublicApi.create(LyftPublicApiRx.class);
@@ -44,31 +82,70 @@ public class LyftApiFactory {
     /**
      * @return An implementation of Lyft's User API endpoints that REQUIRE a user access token.
      * The return type of API calls will be {@link retrofit2.Call}. Used by the LyftButton.
+     *
+     * By default, the Retrofit client will throw a {@link com.lyft.networking.exceptions.PartialResponseException}
+     * if the response returned by the server has missing information (i.e. non-null values returned as null).
+     * To explicitly disallow this, invoke #getLyftUserApi(boolean).
      */
+    public LyftUserApi getLyftUserApi() {
+        return getLyftUserApi(true);
+    }
 
-    public LyftUserApi getLyftUserApi()
-    {
-        Retrofit retrofitUserApi = getRetrofitBuilder(getUserOkHttpClient()).build();
+    /**
+     * @param requiresCompleteResponse A boolean flag to indicate whether an exception should be thrown
+     *                                 if the server returns partial data. If set true,
+     *                                 the Retrofit client will throw a {@link com.lyft.networking.exceptions.PartialResponseException}
+     *                                 when the response returned by the server has missing information (i.e. non-null values returned as null).
+     * @return An implementation of Lyft's User API endpoints that REQUIRE a user access token.
+     * The return type of API calls will be {@link retrofit2.Call}. Used by the LyftButton.
+     *
+     * See: <a href="http://petstore.swagger.io/?url=https://api.lyft.com/v1/spec#!/Public/">http://petstore.swagger.io/?url=https://api.lyft.com/v1/spec#!/Public/</a>
+     */
+    public LyftUserApi getLyftUserApi(boolean requiresCompleteResponse) {
+        Retrofit retrofitUserApi = getRetrofitBuilder(getUserOkHttpClient(), requiresCompleteResponse).build();
         return retrofitUserApi.create(LyftUserApi.class);
     }
 
     /**
      * @return An implementation of Lyft's User API endpoints that REQUIRE a user access token.
      * The return type of API calls will be {@link rx.Observable}. Used by the LyftButton.
+     *
+     * By default, the Retrofit client will throw a {@link com.lyft.networking.exceptions.PartialResponseException}
+     * if the response returned by the server has missing information (i.e. non-null values returned as null).
+     * To explicitly disallow this, invoke #getLyftUserApiRx(boolean).
      */
     public LyftUserApiRx getLyftUserApiRx() {
-        Retrofit retrofitUserApi = getRetrofitBuilder(getUserOkHttpClient())
+        return getLyftUserApiRx(true);
+    }
+
+
+    /**
+     * @param requiresCompleteResponse A boolean flag to indicate whether an exception should be thrown
+     *                                 if the server returns partial data. If set true,
+     *                                 the Retrofit client will throw a {@link com.lyft.networking.exceptions.PartialResponseException}
+     *                                 when the response returned by the server has missing information (i.e. non-null values returned as null).
+     * @return An implementation of Lyft's User API endpoints that REQUIRE a user access token.
+     * The return type of API calls will be {@link rx.Observable}. Used by the LyftButton.
+     *
+     * See: <a href="http://petstore.swagger.io/?url=https://api.lyft.com/v1/spec#!/Public/">http://petstore.swagger.io/?url=https://api.lyft.com/v1/spec#!/Public/</a>
+     */
+    public LyftUserApiRx getLyftUserApiRx(boolean requiresCompleteResponse) {
+        Retrofit retrofitUserApi = getRetrofitBuilder(getUserOkHttpClient(), false)
                 .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
                 .build();
         return retrofitUserApi.create(LyftUserApiRx.class);
     }
 
-    private Retrofit.Builder getRetrofitBuilder(OkHttpClient client) {
-        return new Retrofit.Builder()
+    private Retrofit.Builder getRetrofitBuilder(OkHttpClient client, boolean requiresCompleteResponse) {
+        Retrofit.Builder builder = new Retrofit.Builder()
                 .baseUrl(LyftPublicApi.API_ROOT)
-                .client(client)
-                .addConverterFactory(new NullCheckErrorConverter())
-                .addConverterFactory(GsonConverterFactory.create());
+                .client(client);
+
+        if (requiresCompleteResponse) {
+            builder.addConverterFactory(new NullCheckErrorConverter());
+        }
+
+        return builder.addConverterFactory(GsonConverterFactory.create());
     }
 
     private OkHttpClient getPublicOkHttpClient()

--- a/networking/src/main/java/com/lyft/networking/LyftApiFactory.java
+++ b/networking/src/main/java/com/lyft/networking/LyftApiFactory.java
@@ -5,6 +5,7 @@ import com.lyft.networking.apis.LyftPublicApiRx;
 import com.lyft.networking.apis.LyftUserApi;
 import com.lyft.networking.apis.LyftUserApiRx;
 
+import com.lyft.networking.internal.NullCheckErrorConverter;
 import okhttp3.OkHttpClient;
 import retrofit2.Retrofit;
 import retrofit2.adapter.rxjava.RxJavaCallAdapterFactory;
@@ -66,6 +67,7 @@ public class LyftApiFactory {
         return new Retrofit.Builder()
                 .baseUrl(LyftPublicApi.API_ROOT)
                 .client(client)
+                .addConverterFactory(new NullCheckErrorConverter())
                 .addConverterFactory(GsonConverterFactory.create());
     }
 

--- a/networking/src/main/java/com/lyft/networking/LyftApiFactory.java
+++ b/networking/src/main/java/com/lyft/networking/LyftApiFactory.java
@@ -23,34 +23,28 @@ public class LyftApiFactory {
      * @return An implementation of Lyft's Public API endpoints that do not require a user.
      * The return type of API calls will be {@link retrofit2.Call}. Used by the LyftButton.
      *
-     * By default, the Retrofit client will throw a {@link com.lyft.networking.exceptions.PartialResponseException}
+     * The Retrofit client will throw a {@link com.lyft.networking.exceptions.PartialResponseException}
      * if the response returned by the server has missing information (i.e. non-null values returned as null).
      *
      * THE CALLER MUST be able to handle {@link com.lyft.networking.exceptions.PartialResponseException}.
      * Unhandled exceptions will cause a runtime crash.
      *
-     * To explicitly disallow this, invoke #getLyftPublicApi(boolean).
+     * To avoid an exception and manually handle null checking, use #getUnchekedLyftPublicApi().
      */
     public LyftPublicApi getLyftPublicApi() {
-        return getLyftPublicApi(true);
+        Retrofit retrofitPublicApi = getRetrofitBuilder(getPublicOkHttpClient(), true).build();
+        return retrofitPublicApi.create(LyftPublicApi.class);
     }
 
     /**
-     * Creates an implementation of Lyft's Public API, with an option of generating {@link com.lyft.networking.exceptions.PartialResponseException}
-     * should the server return incomplete response models.
-     *
-     * @param requiresCompleteResponse A boolean flag to indicate whether an exception should be thrown
-     *                                 if the server returns partial data. If set true,
-     *                                 the Retrofit client will throw a {@link com.lyft.networking.exceptions.PartialResponseException}
-     *                                 when the response returned by the server has missing information (i.e. non-null values returned as null).
-     *
-     *                                 ONLY SET AS FALSE if the consumer is responsible for manually handling null checks.
-     *
      * @return An implementation of Lyft's Public API endpoints that do not require a user.
      * The return type of API calls will be {@link retrofit2.Call}. Used by the LyftButton.
+     *
+     * The Retrofit client will not massage the response passed by the server. It is the responsibility of the caller
+     * to verify that the required contents of each payload is non-null before access.
      */
-    public LyftPublicApi getLyftPublicApi(boolean requiresCompleteResponse) {
-        Retrofit retrofitPublicApi = getRetrofitBuilder(getPublicOkHttpClient(), requiresCompleteResponse).build();
+    public LyftPublicApi getUnchekedLyftPublicApi() {
+        Retrofit retrofitPublicApi = getRetrofitBuilder(getPublicOkHttpClient(), false).build();
         return retrofitPublicApi.create(LyftPublicApi.class);
     }
 
@@ -58,31 +52,30 @@ public class LyftApiFactory {
      * @return An implementation of Lyft's Public API endpoints that do not require a user.
      * The return type of API calls will be {@link rx.Observable}.
      *
-     * By default, the Retrofit client will throw a {@link com.lyft.networking.exceptions.PartialResponseException}
+     * The Retrofit client will throw a {@link com.lyft.networking.exceptions.PartialResponseException}
      * if the response returned by the server has missing information (i.e. non-null values returned as null).
      *
      * THE CALLER MUST be able to handle {@link com.lyft.networking.exceptions.PartialResponseException}.
      * Unhandled exceptions will cause a runtime crash.
      *
-     * To explicitly disallow this, invoke #getLyftPublicApiRx(boolean).
+     * To avoid an exception and manually handle null checking, use #getUnchekedLyftPublicApiRx().
      */
     public LyftPublicApiRx getLyftPublicApiRx() {
-        return getLyftPublicApiRx(true);
+        Retrofit retrofitPublicApi = getRetrofitBuilder(getPublicOkHttpClient(), true)
+                .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
+                .build();
+        return retrofitPublicApi.create(LyftPublicApiRx.class);
     }
 
     /**
-     * @param requiresCompleteResponse A boolean flag to indicate whether an exception should be thrown
-     *                                 if the server returns partial data. If set true,
-     *                                 the Retrofit client will throw a {@link com.lyft.networking.exceptions.PartialResponseException}
-     *                                 when the response returned by the server has missing information (i.e. non-null values returned as null).
-     *
-     *                                 ONLY SET AS FALSE if the consumer is responsible for manually handling null checks.
-     *
      * @return An implementation of Lyft's Public API endpoints that do not require a user.
      * The return type of API calls will be {@link rx.Observable}.
+     *
+     * The Retrofit client will not massage the response passed by the server. It is the responsibility of the caller
+     * to verify that the required contents of each payload is non-null before access.
      */
-    public LyftPublicApiRx getLyftPublicApiRx(boolean requiresCompleteResponse) {
-        Retrofit retrofitPublicApi = getRetrofitBuilder(getPublicOkHttpClient(), requiresCompleteResponse)
+    public LyftPublicApiRx getUncheckedLyftPublicApiRx() {
+        Retrofit retrofitPublicApi = getRetrofitBuilder(getPublicOkHttpClient(), false)
                 .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
                 .build();
         return retrofitPublicApi.create(LyftPublicApiRx.class);
@@ -92,31 +85,28 @@ public class LyftApiFactory {
      * @return An implementation of Lyft's User API endpoints that REQUIRE a user access token.
      * The return type of API calls will be {@link retrofit2.Call}. Used by the LyftButton.
      *
-     * By default, the Retrofit client will throw a {@link com.lyft.networking.exceptions.PartialResponseException}
+     * The Retrofit client will throw a {@link com.lyft.networking.exceptions.PartialResponseException}
      * if the response returned by the server has missing information (i.e. non-null values returned as null).
      *
      * THE CALLER MUST be able to handle {@link com.lyft.networking.exceptions.PartialResponseException}.
      * Unhandled exceptions will cause a runtime crash.
      *
-     * To explicitly disallow this, invoke #getLyftUserApi(boolean).
+     * To explicitly disallow this, invoke #getUncheckedLyftUserApi().
      */
     public LyftUserApi getLyftUserApi() {
-        return getLyftUserApi(true);
+        Retrofit retrofitUserApi = getRetrofitBuilder(getUserOkHttpClient(), true).build();
+        return retrofitUserApi.create(LyftUserApi.class);
     }
 
     /**
-     * @param requiresCompleteResponse A boolean flag to indicate whether an exception should be thrown
-     *                                 if the server returns partial data. If set true,
-     *                                 the Retrofit client will throw a {@link com.lyft.networking.exceptions.PartialResponseException}
-     *                                 when the response returned by the server has missing information (i.e. non-null values returned as null).
-     *
-     *                                 ONLY SET AS FALSE if the consumer is responsible for manually handling null checks.
-     *
      * @return An implementation of Lyft's User API endpoints that REQUIRE a user access token.
      * The return type of API calls will be {@link retrofit2.Call}. Used by the LyftButton.
+     *
+     * The Retrofit client will not massage the response passed by the server. It is the responsibility of the caller
+     * to verify that the required contents of each payload is non-null before access.
      */
-    public LyftUserApi getLyftUserApi(boolean requiresCompleteResponse) {
-        Retrofit retrofitUserApi = getRetrofitBuilder(getUserOkHttpClient(), requiresCompleteResponse).build();
+    public LyftUserApi getUncheckedLyftUserApi() {
+        Retrofit retrofitUserApi = getRetrofitBuilder(getUserOkHttpClient(), false).build();
         return retrofitUserApi.create(LyftUserApi.class);
     }
 
@@ -124,32 +114,31 @@ public class LyftApiFactory {
      * @return An implementation of Lyft's User API endpoints that REQUIRE a user access token.
      * The return type of API calls will be {@link rx.Observable}. Used by the LyftButton.
      *
-     * By default, the Retrofit client will throw a {@link com.lyft.networking.exceptions.PartialResponseException}
+     * The Retrofit client will throw a {@link com.lyft.networking.exceptions.PartialResponseException}
      * if the response returned by the server has missing information (i.e. non-null values returned as null).
      *
      * THE CALLER MUST be able to handle {@link com.lyft.networking.exceptions.PartialResponseException}.
      * Unhandled exceptions will cause a runtime crash.
      *
-     * To explicitly disallow this, invoke #getLyftUserApiRx(boolean).
+     * To explicitly disallow this, invoke #getLyftUncheckedUserApiRx().
      */
     public LyftUserApiRx getLyftUserApiRx() {
-        return getLyftUserApiRx(true);
+        Retrofit retrofitUserApi = getRetrofitBuilder(getUserOkHttpClient(), true)
+                .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
+                .build();
+        return retrofitUserApi.create(LyftUserApiRx.class);
     }
 
 
     /**
-     * @param requiresCompleteResponse A boolean flag to indicate whether an exception should be thrown
-     *                                 if the server returns partial data. If set true,
-     *                                 the Retrofit client will throw a {@link com.lyft.networking.exceptions.PartialResponseException}
-     *                                 when the response returned by the server has missing information (i.e. non-null values returned as null).
-     *
-     *                                 ONLY SET AS FALSE if the consumer is responsible for manually handling null checks.
-     *
      * @return An implementation of Lyft's User API endpoints that REQUIRE a user access token.
      * The return type of API calls will be {@link rx.Observable}. Used by the LyftButton.
+     *
+     * The Retrofit client will not massage the response passed by the server. It is the responsibility of the caller
+     * to verify that the required contents of each payload is non-null before access.
      */
-    public LyftUserApiRx getLyftUserApiRx(boolean requiresCompleteResponse) {
-        Retrofit retrofitUserApi = getRetrofitBuilder(getUserOkHttpClient(), requiresCompleteResponse)
+    public LyftUserApiRx getUncheckedLyftUserApiRx() {
+        Retrofit retrofitUserApi = getRetrofitBuilder(getUserOkHttpClient(), false)
                 .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
                 .build();
         return retrofitUserApi.create(LyftUserApiRx.class);

--- a/networking/src/main/java/com/lyft/networking/LyftApiFactory.java
+++ b/networking/src/main/java/com/lyft/networking/LyftApiFactory.java
@@ -25,6 +25,10 @@ public class LyftApiFactory {
      *
      * By default, the Retrofit client will throw a {@link com.lyft.networking.exceptions.PartialResponseException}
      * if the response returned by the server has missing information (i.e. non-null values returned as null).
+     *
+     * THE CALLER MUST be able to handle {@link com.lyft.networking.exceptions.PartialResponseException}.
+     * Unhandled exceptions will cause a runtime crash.
+     *
      * To explicitly disallow this, invoke #getLyftPublicApi(boolean).
      */
     public LyftPublicApi getLyftPublicApi() {
@@ -32,10 +36,16 @@ public class LyftApiFactory {
     }
 
     /**
+     * Creates an implementation of Lyft's Public API, with an option of generating {@link com.lyft.networking.exceptions.PartialResponseException}
+     * should the server return incomplete response models.
+     *
      * @param requiresCompleteResponse A boolean flag to indicate whether an exception should be thrown
      *                                 if the server returns partial data. If set true,
      *                                 the Retrofit client will throw a {@link com.lyft.networking.exceptions.PartialResponseException}
      *                                 when the response returned by the server has missing information (i.e. non-null values returned as null).
+     *
+     *                                 ONLY SET AS FALSE if the consumer is responsible for manually handling null checks.
+     *
      * @return An implementation of Lyft's Public API endpoints that do not require a user.
      * The return type of API calls will be {@link retrofit2.Call}. Used by the LyftButton.
      */
@@ -50,6 +60,10 @@ public class LyftApiFactory {
      *
      * By default, the Retrofit client will throw a {@link com.lyft.networking.exceptions.PartialResponseException}
      * if the response returned by the server has missing information (i.e. non-null values returned as null).
+     *
+     * THE CALLER MUST be able to handle {@link com.lyft.networking.exceptions.PartialResponseException}.
+     * Unhandled exceptions will cause a runtime crash.
+     *
      * To explicitly disallow this, invoke #getLyftPublicApiRx(boolean).
      */
     public LyftPublicApiRx getLyftPublicApiRx() {
@@ -61,6 +75,9 @@ public class LyftApiFactory {
      *                                 if the server returns partial data. If set true,
      *                                 the Retrofit client will throw a {@link com.lyft.networking.exceptions.PartialResponseException}
      *                                 when the response returned by the server has missing information (i.e. non-null values returned as null).
+     *
+     *                                 ONLY SET AS FALSE if the consumer is responsible for manually handling null checks.
+     *
      * @return An implementation of Lyft's Public API endpoints that do not require a user.
      * The return type of API calls will be {@link rx.Observable}.
      */
@@ -77,6 +94,10 @@ public class LyftApiFactory {
      *
      * By default, the Retrofit client will throw a {@link com.lyft.networking.exceptions.PartialResponseException}
      * if the response returned by the server has missing information (i.e. non-null values returned as null).
+     *
+     * THE CALLER MUST be able to handle {@link com.lyft.networking.exceptions.PartialResponseException}.
+     * Unhandled exceptions will cause a runtime crash.
+     *
      * To explicitly disallow this, invoke #getLyftUserApi(boolean).
      */
     public LyftUserApi getLyftUserApi() {
@@ -88,6 +109,9 @@ public class LyftApiFactory {
      *                                 if the server returns partial data. If set true,
      *                                 the Retrofit client will throw a {@link com.lyft.networking.exceptions.PartialResponseException}
      *                                 when the response returned by the server has missing information (i.e. non-null values returned as null).
+     *
+     *                                 ONLY SET AS FALSE if the consumer is responsible for manually handling null checks.
+     *
      * @return An implementation of Lyft's User API endpoints that REQUIRE a user access token.
      * The return type of API calls will be {@link retrofit2.Call}. Used by the LyftButton.
      */
@@ -102,6 +126,10 @@ public class LyftApiFactory {
      *
      * By default, the Retrofit client will throw a {@link com.lyft.networking.exceptions.PartialResponseException}
      * if the response returned by the server has missing information (i.e. non-null values returned as null).
+     *
+     * THE CALLER MUST be able to handle {@link com.lyft.networking.exceptions.PartialResponseException}.
+     * Unhandled exceptions will cause a runtime crash.
+     *
      * To explicitly disallow this, invoke #getLyftUserApiRx(boolean).
      */
     public LyftUserApiRx getLyftUserApiRx() {
@@ -114,11 +142,14 @@ public class LyftApiFactory {
      *                                 if the server returns partial data. If set true,
      *                                 the Retrofit client will throw a {@link com.lyft.networking.exceptions.PartialResponseException}
      *                                 when the response returned by the server has missing information (i.e. non-null values returned as null).
+     *
+     *                                 ONLY SET AS FALSE if the consumer is responsible for manually handling null checks.
+     *
      * @return An implementation of Lyft's User API endpoints that REQUIRE a user access token.
      * The return type of API calls will be {@link rx.Observable}. Used by the LyftButton.
      */
     public LyftUserApiRx getLyftUserApiRx(boolean requiresCompleteResponse) {
-        Retrofit retrofitUserApi = getRetrofitBuilder(getUserOkHttpClient(), false)
+        Retrofit retrofitUserApi = getRetrofitBuilder(getUserOkHttpClient(), requiresCompleteResponse)
                 .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
                 .build();
         return retrofitUserApi.create(LyftUserApiRx.class);

--- a/networking/src/main/java/com/lyft/networking/LyftApiFactory.java
+++ b/networking/src/main/java/com/lyft/networking/LyftApiFactory.java
@@ -26,8 +26,6 @@ public class LyftApiFactory {
      * By default, the Retrofit client will throw a {@link com.lyft.networking.exceptions.PartialResponseException}
      * if the response returned by the server has missing information (i.e. non-null values returned as null).
      * To explicitly disallow this, invoke #getLyftPublicApi(boolean).
-     *
-     * See: <a href="http://petstore.swagger.io/?url=https://api.lyft.com/v1/spec#!/Public/">http://petstore.swagger.io/?url=https://api.lyft.com/v1/spec#!/Public/</a>
      */
     public LyftPublicApi getLyftPublicApi() {
         return getLyftPublicApi(true);
@@ -40,8 +38,6 @@ public class LyftApiFactory {
      *                                 when the response returned by the server has missing information (i.e. non-null values returned as null).
      * @return An implementation of Lyft's Public API endpoints that do not require a user.
      * The return type of API calls will be {@link retrofit2.Call}. Used by the LyftButton.
-     *
-     * See: <a href="http://petstore.swagger.io/?url=https://api.lyft.com/v1/spec#!/Public/">http://petstore.swagger.io/?url=https://api.lyft.com/v1/spec#!/Public/</a>
      */
     public LyftPublicApi getLyftPublicApi(boolean requiresCompleteResponse) {
         Retrofit retrofitPublicApi = getRetrofitBuilder(getPublicOkHttpClient(), requiresCompleteResponse).build();
@@ -55,8 +51,6 @@ public class LyftApiFactory {
      * By default, the Retrofit client will throw a {@link com.lyft.networking.exceptions.PartialResponseException}
      * if the response returned by the server has missing information (i.e. non-null values returned as null).
      * To explicitly disallow this, invoke #getLyftPublicApiRx(boolean).
-     *
-     * See: <a href="http://petstore.swagger.io/?url=https://api.lyft.com/v1/spec#!/Public/">http://petstore.swagger.io/?url=https://api.lyft.com/v1/spec#!/Public/</a>
      */
     public LyftPublicApiRx getLyftPublicApiRx() {
         return getLyftPublicApiRx(true);
@@ -69,8 +63,6 @@ public class LyftApiFactory {
      *                                 when the response returned by the server has missing information (i.e. non-null values returned as null).
      * @return An implementation of Lyft's Public API endpoints that do not require a user.
      * The return type of API calls will be {@link rx.Observable}.
-     *
-     * See: <a href="http://petstore.swagger.io/?url=https://api.lyft.com/v1/spec#!/Public/">http://petstore.swagger.io/?url=https://api.lyft.com/v1/spec#!/Public/</a>
      */
     public LyftPublicApiRx getLyftPublicApiRx(boolean requiresCompleteResponse) {
         Retrofit retrofitPublicApi = getRetrofitBuilder(getPublicOkHttpClient(), requiresCompleteResponse)
@@ -98,8 +90,6 @@ public class LyftApiFactory {
      *                                 when the response returned by the server has missing information (i.e. non-null values returned as null).
      * @return An implementation of Lyft's User API endpoints that REQUIRE a user access token.
      * The return type of API calls will be {@link retrofit2.Call}. Used by the LyftButton.
-     *
-     * See: <a href="http://petstore.swagger.io/?url=https://api.lyft.com/v1/spec#!/Public/">http://petstore.swagger.io/?url=https://api.lyft.com/v1/spec#!/Public/</a>
      */
     public LyftUserApi getLyftUserApi(boolean requiresCompleteResponse) {
         Retrofit retrofitUserApi = getRetrofitBuilder(getUserOkHttpClient(), requiresCompleteResponse).build();
@@ -126,8 +116,6 @@ public class LyftApiFactory {
      *                                 when the response returned by the server has missing information (i.e. non-null values returned as null).
      * @return An implementation of Lyft's User API endpoints that REQUIRE a user access token.
      * The return type of API calls will be {@link rx.Observable}. Used by the LyftButton.
-     *
-     * See: <a href="http://petstore.swagger.io/?url=https://api.lyft.com/v1/spec#!/Public/">http://petstore.swagger.io/?url=https://api.lyft.com/v1/spec#!/Public/</a>
      */
     public LyftUserApiRx getLyftUserApiRx(boolean requiresCompleteResponse) {
         Retrofit retrofitUserApi = getRetrofitBuilder(getUserOkHttpClient(), false)

--- a/networking/src/main/java/com/lyft/networking/apiObjects/CostEstimate.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/CostEstimate.java
@@ -1,13 +1,13 @@
 package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
-import com.lyft.networking.apiObjects.internal.ICompleteData;
+import com.lyft.networking.apiObjects.internal.Validatable;
 import org.jetbrains.annotations.Nullable;
 
 /**
  * A non-guaranteed estimate of price
  **/
-public class CostEstimate implements ICompleteData {
+public class CostEstimate implements Validatable {
 
     /**
      * Ride type one of: (lyft, lyft_plus, lyft_line, lyft_premier, lyft_lux, lyft_luxsuv)

--- a/networking/src/main/java/com/lyft/networking/apiObjects/CostEstimate.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/CostEstimate.java
@@ -1,11 +1,13 @@
 package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
+import com.lyft.networking.apiObjects.internal.ICompleteData;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A non-guaranteed estimate of price
  **/
-public class CostEstimate {
+public class CostEstimate implements ICompleteData {
 
     /**
      * Ride type one of: (lyft, lyft_plus, lyft_line, lyft_premier, lyft_lux, lyft_luxsuv)
@@ -61,12 +63,17 @@ public class CostEstimate {
      * A token that should be used to confirm that the user has accepted current Prime Time
      * and/or fixed price charges. See note above.
      */
+    @Nullable
     @SerializedName("cost_token")
     public final String cost_token;
 
     /**
+     * @Deprecated use {@link #cost_token} instead.
+     *
      * A token that should be used to confirm that the user has accepted current Prime Time pricing.
      */
+    @Nullable
+    @Deprecated
     @SerializedName("primetime_confirmation_token")
     public final String primetime_confirmation_token;
 
@@ -102,5 +109,17 @@ public class CostEstimate {
         sb.append("  cost_token: ").append(cost_token).append("\n");
         sb.append("}\n");
         return sb.toString();
+    }
+
+    @Override
+    public boolean isValid() {
+        return ride_type != null
+                && display_name != null
+                && currency != null
+                && estimated_cost_cents_min != null
+                && estimated_cost_cents_max != null
+                && estimated_distance_miles != null
+                && estimated_duration_seconds != null
+                && primetime_percentage != null;
     }
 }

--- a/networking/src/main/java/com/lyft/networking/apiObjects/CostEstimateResponse.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/CostEstimateResponse.java
@@ -1,9 +1,11 @@
 package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
+import com.lyft.networking.apiObjects.internal.ICompleteData;
+
 import java.util.List;
 
-public class CostEstimateResponse {
+public class CostEstimateResponse implements ICompleteData {
 
     @SerializedName("cost_estimates")
     public final List<CostEstimate> cost_estimates;
@@ -20,5 +22,16 @@ public class CostEstimateResponse {
         sb.append("  cost_estimates: ").append(cost_estimates).append("\n");
         sb.append("}\n");
         return sb.toString();
+    }
+
+    @Override
+    public boolean isValid() {
+        for (CostEstimate costEstimate : cost_estimates) {
+            if (!costEstimate.isValid()) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/networking/src/main/java/com/lyft/networking/apiObjects/CostEstimateResponse.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/CostEstimateResponse.java
@@ -1,11 +1,11 @@
 package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
-import com.lyft.networking.apiObjects.internal.ICompleteData;
+import com.lyft.networking.apiObjects.internal.Validatable;
 
 import java.util.List;
 
-public class CostEstimateResponse implements ICompleteData {
+public class CostEstimateResponse implements Validatable {
 
     @SerializedName("cost_estimates")
     public final List<CostEstimate> cost_estimates;

--- a/networking/src/main/java/com/lyft/networking/apiObjects/Eta.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/Eta.java
@@ -1,11 +1,12 @@
 package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
+import com.lyft.networking.apiObjects.internal.ICompleteData;
 
 /**
  * Estimated Time of Arrival
  **/
-public class Eta {
+public class Eta implements ICompleteData {
 
     @SerializedName("ride_type")
     public final String ride_type;
@@ -32,5 +33,13 @@ public class Eta {
         sb.append("  eta_seconds: ").append(eta_seconds).append("\n");
         sb.append("}\n");
         return sb.toString();
+    }
+
+
+    @Override
+    public boolean isValid() {
+        return ride_type != null
+                && display_name != null
+                && eta_seconds != null;
     }
 }

--- a/networking/src/main/java/com/lyft/networking/apiObjects/Eta.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/Eta.java
@@ -1,12 +1,12 @@
 package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
-import com.lyft.networking.apiObjects.internal.ICompleteData;
+import com.lyft.networking.apiObjects.internal.Validatable;
 
 /**
  * Estimated Time of Arrival
  **/
-public class Eta implements ICompleteData {
+public class Eta implements Validatable {
 
     @SerializedName("ride_type")
     public final String ride_type;

--- a/networking/src/main/java/com/lyft/networking/apiObjects/EtaEstimateResponse.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/EtaEstimateResponse.java
@@ -1,11 +1,11 @@
 package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
-import com.lyft.networking.apiObjects.internal.ICompleteData;
+import com.lyft.networking.apiObjects.internal.Validatable;
 
 import java.util.List;
 
-public class EtaEstimateResponse implements ICompleteData {
+public class EtaEstimateResponse implements Validatable {
 
     @SerializedName("eta_estimates")
     public final List<Eta> eta_estimates;

--- a/networking/src/main/java/com/lyft/networking/apiObjects/EtaEstimateResponse.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/EtaEstimateResponse.java
@@ -1,9 +1,11 @@
 package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
+import com.lyft.networking.apiObjects.internal.ICompleteData;
+
 import java.util.List;
 
-public class EtaEstimateResponse {
+public class EtaEstimateResponse implements ICompleteData {
 
     @SerializedName("eta_estimates")
     public final List<Eta> eta_estimates;
@@ -20,5 +22,15 @@ public class EtaEstimateResponse {
         sb.append("  eta_estimates: ").append(eta_estimates).append("\n");
         sb.append("}\n");
         return sb.toString();
+    }
+
+    @Override
+    public boolean isValid() {
+        for (Eta etaEstimate : eta_estimates) {
+            if (!etaEstimate.isValid()) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/networking/src/main/java/com/lyft/networking/apiObjects/LatLng.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/LatLng.java
@@ -1,9 +1,9 @@
 package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
-import com.lyft.networking.apiObjects.internal.ICompleteData;
+import com.lyft.networking.apiObjects.internal.Validatable;
 
-public class LatLng implements ICompleteData {
+public class LatLng implements Validatable {
 
     @SerializedName("lat")
     public final Double lat;

--- a/networking/src/main/java/com/lyft/networking/apiObjects/LatLng.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/LatLng.java
@@ -1,8 +1,9 @@
 package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
+import com.lyft.networking.apiObjects.internal.ICompleteData;
 
-public class LatLng {
+public class LatLng implements ICompleteData {
 
     @SerializedName("lat")
     public final Double lat;
@@ -24,5 +25,10 @@ public class LatLng {
         sb.append("  lng: ").append(lng).append("\n");
         sb.append("}\n");
         return sb.toString();
+    }
+
+    @Override
+    public boolean isValid() {
+        return lat != null && lng != null;
     }
 }

--- a/networking/src/main/java/com/lyft/networking/apiObjects/LyftLocation.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/LyftLocation.java
@@ -1,6 +1,8 @@
 package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
+import com.lyft.networking.apiObjects.internal.ICompleteData;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Model containing information about a Lyft Location.
@@ -8,19 +10,26 @@ import com.google.gson.annotations.SerializedName;
  * location of rides on the Lyft Platform.
  */
 
-public class LyftLocation extends LatLng
-{
+public class LyftLocation extends LatLng implements ICompleteData {
     /**
      * Display address at/near the given location.
      */
+    @Nullable
     @SerializedName("address")
     public String address = null;
-    public LyftLocation(){ this(0, 0);}
-    public LyftLocation(double lat, double lng) { this(lat, lng, null); }
-    public LyftLocation(double lat, double lng, String address)
-    {
+
+    public LyftLocation() {
+        this(0, 0);
+    }
+
+    public LyftLocation(double lat, double lng) {
+        this(lat, lng, null);
+    }
+
+    public LyftLocation(double lat, double lng, String address) {
         super(lat, lng);
         this.address = address;
     }
+
 
 }

--- a/networking/src/main/java/com/lyft/networking/apiObjects/LyftLocation.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/LyftLocation.java
@@ -1,7 +1,7 @@
 package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
-import com.lyft.networking.apiObjects.internal.ICompleteData;
+import com.lyft.networking.apiObjects.internal.Validatable;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -10,7 +10,7 @@ import org.jetbrains.annotations.Nullable;
  * location of rides on the Lyft Platform.
  */
 
-public class LyftLocation extends LatLng implements ICompleteData {
+public class LyftLocation extends LatLng implements Validatable {
     /**
      * Display address at/near the given location.
      */

--- a/networking/src/main/java/com/lyft/networking/apiObjects/LyftUser.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/LyftUser.java
@@ -1,14 +1,14 @@
 package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
+import com.lyft.networking.apiObjects.internal.ICompleteData;
 
 /**
  * Represents a user object model on the Lyft API.
  * This object model can be used to represent the base line
  * information for a driver or a passenger on the Lyft platform
  */
-public class LyftUser
-{
+public class LyftUser implements ICompleteData {
     /**
      * Rating of the user; current rating (0.0 – 5.0).
      */
@@ -35,4 +35,12 @@ public class LyftUser
     @SerializedName("image_url")
     public String image_url;
 
+    @Override
+    public boolean isValid() {
+        return rating != null
+                && user_id != null
+                && first_name != null
+                && last_name != null
+                && image_url != null;
+    }
 }

--- a/networking/src/main/java/com/lyft/networking/apiObjects/LyftUser.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/LyftUser.java
@@ -1,14 +1,14 @@
 package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
-import com.lyft.networking.apiObjects.internal.ICompleteData;
+import com.lyft.networking.apiObjects.internal.Validatable;
 
 /**
  * Represents a user object model on the Lyft API.
  * This object model can be used to represent the base line
  * information for a driver or a passenger on the Lyft platform
  */
-public class LyftUser implements ICompleteData {
+public class LyftUser implements Validatable {
     /**
      * Rating of the user; current rating (0.0 – 5.0).
      */

--- a/networking/src/main/java/com/lyft/networking/apiObjects/NearbyDriver.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/NearbyDriver.java
@@ -1,9 +1,11 @@
 package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
+import com.lyft.networking.apiObjects.internal.ICompleteData;
+
 import java.util.List;
 
-public class NearbyDriver {
+public class NearbyDriver implements ICompleteData {
 
     @SerializedName("locations")
     public final List<LatLng> locations;
@@ -20,5 +22,15 @@ public class NearbyDriver {
         sb.append("  locations: ").append(locations).append("\n");
         sb.append("}\n");
         return sb.toString();
+    }
+
+    @Override
+    public boolean isValid() {
+        for (LatLng location : locations) {
+            if (!location.isValid()) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/networking/src/main/java/com/lyft/networking/apiObjects/NearbyDriver.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/NearbyDriver.java
@@ -1,11 +1,11 @@
 package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
-import com.lyft.networking.apiObjects.internal.ICompleteData;
+import com.lyft.networking.apiObjects.internal.Validatable;
 
 import java.util.List;
 
-public class NearbyDriver implements ICompleteData {
+public class NearbyDriver implements Validatable {
 
     @SerializedName("locations")
     public final List<LatLng> locations;

--- a/networking/src/main/java/com/lyft/networking/apiObjects/NearbyDriversByRideType.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/NearbyDriversByRideType.java
@@ -1,11 +1,11 @@
 package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
-import com.lyft.networking.apiObjects.internal.ICompleteData;
+import com.lyft.networking.apiObjects.internal.Validatable;
 
 import java.util.List;
 
-public class NearbyDriversByRideType implements ICompleteData {
+public class NearbyDriversByRideType implements Validatable {
 
     @SerializedName("ride_type")
     public final String ride_type;

--- a/networking/src/main/java/com/lyft/networking/apiObjects/NearbyDriversByRideType.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/NearbyDriversByRideType.java
@@ -1,9 +1,11 @@
 package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
+import com.lyft.networking.apiObjects.internal.ICompleteData;
+
 import java.util.List;
 
-public class NearbyDriversByRideType {
+public class NearbyDriversByRideType implements ICompleteData {
 
     @SerializedName("ride_type")
     public final String ride_type;
@@ -25,5 +27,15 @@ public class NearbyDriversByRideType {
         sb.append("  drivers: ").append(drivers).append("\n");
         sb.append("}\n");
         return sb.toString();
+    }
+
+    @Override
+    public boolean isValid() {
+        for (NearbyDriver driver : drivers) {
+            if (!driver.isValid()) {
+                return false;
+            }
+        }
+        return ride_type != null;
     }
 }

--- a/networking/src/main/java/com/lyft/networking/apiObjects/NearbyDriversResponse.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/NearbyDriversResponse.java
@@ -1,11 +1,11 @@
 package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
-import com.lyft.networking.apiObjects.internal.ICompleteData;
+import com.lyft.networking.apiObjects.internal.Validatable;
 
 import java.util.List;
 
-public class NearbyDriversResponse implements ICompleteData {
+public class NearbyDriversResponse implements Validatable {
 
     @SerializedName("nearby_drivers")
     public final List<NearbyDriversByRideType> nearby_drivers;

--- a/networking/src/main/java/com/lyft/networking/apiObjects/NearbyDriversResponse.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/NearbyDriversResponse.java
@@ -1,9 +1,11 @@
 package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
+import com.lyft.networking.apiObjects.internal.ICompleteData;
+
 import java.util.List;
 
-public class NearbyDriversResponse {
+public class NearbyDriversResponse implements ICompleteData {
 
     @SerializedName("nearby_drivers")
     public final List<NearbyDriversByRideType> nearby_drivers;
@@ -20,5 +22,16 @@ public class NearbyDriversResponse {
         sb.append("  nearby_drivers: ").append(nearby_drivers).append("\n");
         sb.append("}\n");
         return sb.toString();
+    }
+
+    @Override
+    public boolean isValid() {
+        for (NearbyDriversByRideType nearbyDriver : nearby_drivers) {
+            if (!nearbyDriver.isValid()) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/networking/src/main/java/com/lyft/networking/apiObjects/PricingDetails.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/PricingDetails.java
@@ -1,9 +1,9 @@
 package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
-import com.lyft.networking.apiObjects.internal.ICompleteData;
+import com.lyft.networking.apiObjects.internal.Validatable;
 
-public class PricingDetails implements ICompleteData {
+public class PricingDetails implements Validatable {
 
     @SerializedName("base_charge")
     public final Integer base_charge;

--- a/networking/src/main/java/com/lyft/networking/apiObjects/PricingDetails.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/PricingDetails.java
@@ -1,8 +1,9 @@
 package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
+import com.lyft.networking.apiObjects.internal.ICompleteData;
 
-public class PricingDetails {
+public class PricingDetails implements ICompleteData {
 
     @SerializedName("base_charge")
     public final Integer base_charge;
@@ -50,5 +51,16 @@ public class PricingDetails {
         sb.append("  trust_and_service: ").append(trust_and_service).append("\n");
         sb.append("}\n");
         return sb.toString();
+    }
+
+    @Override
+    public boolean isValid() {
+        return base_charge != null
+                && cancel_penalty_amount != null
+                && cost_minimum != null
+                && cost_per_mile != null
+                && cost_per_minute != null
+                && currency != null
+                && trust_and_service != null;
     }
 }

--- a/networking/src/main/java/com/lyft/networking/apiObjects/RideHistory.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/RideHistory.java
@@ -1,13 +1,14 @@
 package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
+import com.lyft.networking.apiObjects.internal.ICompleteData;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A model for an instance of a user's RideHistory
  */
 
-public class RideHistory
-{
+public class RideHistory implements ICompleteData {
     /**
      * Ride id
      */
@@ -41,12 +42,14 @@ public class RideHistory
      * Indicates whether the ride was requested from the business profile or personal
      * profile of the passenger.
      */
+    @Nullable
     @SerializedName("ride_profile")
     public String ride_profile;
 
     /**
      * Amp color HEX code, eg. #FFFFFF.
      */
+    @Nullable
     @SerializedName("beacon_color")
     public String beacon_color;
 
@@ -54,6 +57,7 @@ public class RideHistory
      * Link to a web view showing the pricing structure for the geographic area where
      * the ride was taken.
      */
+    @Nullable
     @SerializedName("pricing_details_url")
     public String pricing_details_url;
 
@@ -62,23 +66,27 @@ public class RideHistory
      * This field will only be present for rides created via the API, or that have been
      * shared through the "Share my Route" feature.
      */
+    @Nullable
     @SerializedName("route_url")
     public String route_url;
 
     /**
      * The role of user who canceled the ride (if applicable).
      */
+    @Nullable
     @SerializedName("canceled_by")
     public String canceled_by;
 
     /**
      * The written feedback the user left for this ride.
      */
+    @Nullable
     @SerializedName("feedback")
     public String feedback;
     /**
      * The array of actors who may cancel the ride at this point (driver, passenger, dispatcher).
      */
+    @Nullable
     @SerializedName("can_cancel")
     public String[] can_cancel;
 
@@ -104,6 +112,7 @@ public class RideHistory
      * Current location of the vehicle. Available after ride status changes
      * to pickedUp and until droppedOff.
      */
+    @Nullable
     @SerializedName("location")
     public LyftLocation location;
 
@@ -159,4 +168,19 @@ public class RideHistory
     public boolean isPending() { return "pending".equalsIgnoreCase(status) || "unknown".equalsIgnoreCase(status); }
 
 
+    @Override
+    public boolean isValid() {
+        return ride_id != null
+                && ride_type != null
+                && status != null
+                && primetime_percentage != null
+                && requested_at != null
+                && pickup.isValid()
+                && destination.isValid()
+                && dropoff.isValid()
+                && origin.isValid()
+                && passenger.isValid()
+                && driver.isValid()
+                && vehicle.isValid();
+    }
 }

--- a/networking/src/main/java/com/lyft/networking/apiObjects/RideHistory.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/RideHistory.java
@@ -1,14 +1,14 @@
 package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
-import com.lyft.networking.apiObjects.internal.ICompleteData;
+import com.lyft.networking.apiObjects.internal.Validatable;
 import org.jetbrains.annotations.Nullable;
 
 /**
  * A model for an instance of a user's RideHistory
  */
 
-public class RideHistory implements ICompleteData {
+public class RideHistory implements Validatable {
     /**
      * Ride id
      */

--- a/networking/src/main/java/com/lyft/networking/apiObjects/RideRequestResponse.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/RideRequestResponse.java
@@ -1,13 +1,13 @@
 package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
-import com.lyft.networking.apiObjects.internal.ICompleteData;
+import com.lyft.networking.apiObjects.internal.Validatable;
 
 /**
  * Response model for requests for Rides on the Lyft Platform
  */
 
-public class RideRequestResponse implements ICompleteData {
+public class RideRequestResponse implements Validatable {
     /**
      * Requested ride ID.
      */

--- a/networking/src/main/java/com/lyft/networking/apiObjects/RideRequestResponse.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/RideRequestResponse.java
@@ -1,13 +1,13 @@
 package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
+import com.lyft.networking.apiObjects.internal.ICompleteData;
 
 /**
  * Response model for requests for Rides on the Lyft Platform
  */
 
-public class RideRequestResponse
-{
+public class RideRequestResponse implements ICompleteData {
     /**
      * Requested ride ID.
      */
@@ -44,4 +44,13 @@ public class RideRequestResponse
     @SerializedName("passenger")
     public LyftUser passenger;
 
+    @Override
+    public boolean isValid() {
+        return ride_id != null
+                && ride_type != null
+                && status != null
+                && origin.isValid()
+                && destination.isValid()
+                && passenger.isValid();
+    }
 }

--- a/networking/src/main/java/com/lyft/networking/apiObjects/RideType.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/RideType.java
@@ -1,8 +1,10 @@
 package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
+import com.lyft.networking.apiObjects.internal.ICompleteData;
+import org.jetbrains.annotations.Nullable;
 
-public class RideType {
+public class RideType implements ICompleteData {
 
     @SerializedName("ride_type")
     public final String ride_type;
@@ -13,23 +15,23 @@ public class RideType {
     @SerializedName("seats")
     public final Integer seats;
 
+    @Nullable
     @SerializedName("image_url")
     public final String image_url;
 
     @SerializedName("pricing_details")
     public final PricingDetails pricing_details;
 
-    @SerializedName("scheduled_pricing_details")
-    public final PricingDetails scheduled_pricing_details;
-
-    public RideType(String ride_type, String display_name, Integer seats, String image_url, PricingDetails pricing_details,
-            PricingDetails scheduled_pricing_details) {
+    public RideType(String ride_type,
+                    String display_name,
+                    Integer seats,
+                    String image_url,
+                    PricingDetails pricing_details) {
         this.ride_type = ride_type;
         this.display_name = display_name;
         this.seats = seats;
         this.image_url = image_url;
         this.pricing_details = pricing_details;
-        this.scheduled_pricing_details = scheduled_pricing_details;
     }
 
     @Override
@@ -42,8 +44,15 @@ public class RideType {
         sb.append("  seats: ").append(seats).append("\n");
         sb.append("  image_url: ").append(image_url).append("\n");
         sb.append("  pricing_details: ").append(pricing_details).append("\n");
-        sb.append("  scheduled_pricing_details: ").append(scheduled_pricing_details).append("\n");
         sb.append("}\n");
         return sb.toString();
+    }
+
+    @Override
+    public boolean isValid() {
+        return ride_type != null
+                && display_name != null
+                && seats != null
+                && pricing_details.isValid();
     }
 }

--- a/networking/src/main/java/com/lyft/networking/apiObjects/RideType.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/RideType.java
@@ -1,10 +1,10 @@
 package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
-import com.lyft.networking.apiObjects.internal.ICompleteData;
+import com.lyft.networking.apiObjects.internal.Validatable;
 import org.jetbrains.annotations.Nullable;
 
-public class RideType implements ICompleteData {
+public class RideType implements Validatable {
 
     @SerializedName("ride_type")
     public final String ride_type;

--- a/networking/src/main/java/com/lyft/networking/apiObjects/RideTypesResponse.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/RideTypesResponse.java
@@ -1,11 +1,11 @@
 package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
-import com.lyft.networking.apiObjects.internal.ICompleteData;
+import com.lyft.networking.apiObjects.internal.Validatable;
 
 import java.util.List;
 
-public class RideTypesResponse implements ICompleteData {
+public class RideTypesResponse implements Validatable {
 
     @SerializedName("ride_types")
     public final List<RideType> ride_types;

--- a/networking/src/main/java/com/lyft/networking/apiObjects/RideTypesResponse.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/RideTypesResponse.java
@@ -1,9 +1,11 @@
 package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
+import com.lyft.networking.apiObjects.internal.ICompleteData;
+
 import java.util.List;
 
-public class RideTypesResponse {
+public class RideTypesResponse implements ICompleteData {
 
     @SerializedName("ride_types")
     public final List<RideType> ride_types;
@@ -20,5 +22,16 @@ public class RideTypesResponse {
         sb.append("  ride_types: ").append(ride_types).append("\n");
         sb.append("}\n");
         return sb.toString();
+    }
+
+    @Override
+    public boolean isValid() {
+        for (RideType rideType : ride_types) {
+            if (!rideType.isValid()) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/networking/src/main/java/com/lyft/networking/apiObjects/UserRideHistoryResponse.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/UserRideHistoryResponse.java
@@ -1,6 +1,7 @@
 package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
+import com.lyft.networking.apiObjects.internal.ICompleteData;
 
 import java.util.List;
 
@@ -8,9 +9,18 @@ import java.util.List;
  * Response model for requests for User Ride History on the Lyft Platform
  */
 
-public class UserRideHistoryResponse
-{
+public class UserRideHistoryResponse implements ICompleteData {
     @SerializedName("ride_history")
     public List<RideHistory> ride_history;
 
+    @Override
+    public boolean isValid() {
+        for (RideHistory rideHistory : ride_history) {
+            if (!rideHistory.isValid()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/networking/src/main/java/com/lyft/networking/apiObjects/UserRideHistoryResponse.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/UserRideHistoryResponse.java
@@ -1,7 +1,7 @@
 package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
-import com.lyft.networking.apiObjects.internal.ICompleteData;
+import com.lyft.networking.apiObjects.internal.Validatable;
 
 import java.util.List;
 
@@ -9,7 +9,7 @@ import java.util.List;
  * Response model for requests for User Ride History on the Lyft Platform
  */
 
-public class UserRideHistoryResponse implements ICompleteData {
+public class UserRideHistoryResponse implements Validatable {
     @SerializedName("ride_history")
     public List<RideHistory> ride_history;
 

--- a/networking/src/main/java/com/lyft/networking/apiObjects/Vehicle.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/Vehicle.java
@@ -1,13 +1,13 @@
 package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
-import com.lyft.networking.apiObjects.internal.ICompleteData;
+import com.lyft.networking.apiObjects.internal.Validatable;
 
 /**
  * Model containing vehicle meta data
  */
 
-public class Vehicle implements ICompleteData {
+public class Vehicle implements Validatable {
     /**
      * Vehicle year
      */

--- a/networking/src/main/java/com/lyft/networking/apiObjects/Vehicle.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/Vehicle.java
@@ -1,13 +1,13 @@
 package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
+import com.lyft.networking.apiObjects.internal.ICompleteData;
 
 /**
  * Model containing vehicle meta data
  */
 
-public class Vehicle
-{
+public class Vehicle implements ICompleteData {
     /**
      * Vehicle year
      */
@@ -45,9 +45,17 @@ public class Vehicle
     public String color;
 
     /**
-     * Vehicle image_ur
+     * Vehicle image_url
      */
-    @SerializedName("image_ur")
+    @SerializedName("image_url")
     public String image_url;
 
+    @Override
+    public boolean isValid() {
+        return make != null
+                && model != null
+                && license_plate != null
+                && license_plate_state != null
+                && image_url != null;
+    }
 }

--- a/networking/src/main/java/com/lyft/networking/apiObjects/internal/ICompleteData.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/internal/ICompleteData.java
@@ -1,0 +1,18 @@
+package com.lyft.networking.apiObjects.internal;
+
+/**
+ * INTERNAL USE ONLY.
+ *
+ * An interface used to verify that Response objects have been rendered correctly and are valid to serve to the client.
+ */
+public interface ICompleteData {
+
+    /**
+     * Invoked by the Retrofit client on the parsed object before returning it to the caller.
+     * If all fields in the parsed response have been rendered correctly (i.e. fields meant to be non-null are non-null)
+     * this method will return true.
+     *
+     * @return true if all fields of the class have been parsed correctly.
+     */
+    boolean isValid();
+}

--- a/networking/src/main/java/com/lyft/networking/apiObjects/internal/ICompleteData.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/internal/ICompleteData.java
@@ -12,6 +12,9 @@ public interface ICompleteData {
      * If all fields in the parsed response have been rendered correctly (i.e. fields meant to be non-null are non-null)
      * this method will return true.
      *
+     * If any fields also implement {@link ICompleteData}, the implementation is responsible for recursively checking
+     * the #isValid() method of those fields.
+     *
      * @return true if all fields of the class have been parsed correctly.
      */
     boolean isValid();

--- a/networking/src/main/java/com/lyft/networking/apiObjects/internal/Validatable.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/internal/Validatable.java
@@ -5,14 +5,14 @@ package com.lyft.networking.apiObjects.internal;
  *
  * An interface used to verify that Response objects have been rendered correctly and are valid to serve to the client.
  */
-public interface ICompleteData {
+public interface Validatable {
 
     /**
      * Invoked by the Retrofit client on the parsed object before returning it to the caller.
      * If all fields in the parsed response have been rendered correctly (i.e. fields meant to be non-null are non-null)
      * this method will return true.
      *
-     * If any fields also implement {@link ICompleteData}, the implementation is responsible for recursively checking
+     * If any fields also implement {@link Validatable}, the implementation is responsible for recursively checking
      * the #isValid() method of those fields.
      *
      * @return true if all fields of the class have been parsed correctly.

--- a/networking/src/main/java/com/lyft/networking/exceptions/PartialResponseException.java
+++ b/networking/src/main/java/com/lyft/networking/exceptions/PartialResponseException.java
@@ -1,0 +1,27 @@
+package com.lyft.networking.exceptions;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+
+/**
+ * Exception thrown when the response returned by the server was incomplete.
+ * Typically, this means when non-null expected fields were parsed as null values.
+ */
+public class PartialResponseException extends IOException {
+
+    Object object;
+
+    public PartialResponseException(@NotNull Object object) {
+        this.object = object;
+    }
+
+    @Override
+    public String getMessage() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("The following object was returned incorrectly by the network:\n")
+                .append(object.toString());
+
+        return sb.toString();
+    }
+}

--- a/networking/src/main/java/com/lyft/networking/internal/NullCheckErrorConverter.java
+++ b/networking/src/main/java/com/lyft/networking/internal/NullCheckErrorConverter.java
@@ -1,6 +1,6 @@
 package com.lyft.networking.internal;
 
-import com.lyft.networking.apiObjects.internal.ICompleteData;
+import com.lyft.networking.apiObjects.internal.Validatable;
 import com.lyft.networking.exceptions.PartialResponseException;
 import okhttp3.ResponseBody;
 import retrofit2.Converter;
@@ -8,7 +8,6 @@ import retrofit2.Retrofit;
 
 import java.io.IOException;
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 
 public class NullCheckErrorConverter extends Converter.Factory {
@@ -22,9 +21,9 @@ public class NullCheckErrorConverter extends Converter.Factory {
             public Object convert(ResponseBody value) throws IOException {
                 Object result = delegate.convert(value);
 
-                if (result instanceof ICompleteData) {
-                    ICompleteData completeData = (ICompleteData) result;
-                    if (!completeData.isValid()) {
+                if (result instanceof Validatable) {
+                    Validatable validatable = (Validatable) result;
+                    if (!validatable.isValid()) {
                         throw new PartialResponseException(result);
                     }
                 }

--- a/networking/src/main/java/com/lyft/networking/internal/NullCheckErrorConverter.java
+++ b/networking/src/main/java/com/lyft/networking/internal/NullCheckErrorConverter.java
@@ -1,0 +1,36 @@
+package com.lyft.networking.internal;
+
+import com.lyft.networking.apiObjects.internal.ICompleteData;
+import com.lyft.networking.exceptions.PartialResponseException;
+import okhttp3.ResponseBody;
+import retrofit2.Converter;
+import retrofit2.Retrofit;
+
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Type;
+
+public class NullCheckErrorConverter extends Converter.Factory {
+
+    @Override
+    public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations, Retrofit retrofit) {
+        final Converter<ResponseBody, ?> delegate = retrofit.nextResponseBodyConverter(this, type, annotations);
+
+        return new Converter<ResponseBody, Object>() {
+            @Override
+            public Object convert(ResponseBody value) throws IOException {
+                Object result = delegate.convert(value);
+
+                if (result instanceof ICompleteData) {
+                    ICompleteData completeData = (ICompleteData) result;
+                    if (!completeData.isValid()) {
+                        throw new PartialResponseException(result);
+                    }
+                }
+
+                return result;
+            }
+        };
+    }
+}

--- a/test-utils/src/main/java/com/lyft/testutils/MockLyftPublicApi.java
+++ b/test-utils/src/main/java/com/lyft/testutils/MockLyftPublicApi.java
@@ -119,14 +119,14 @@ public class MockLyftPublicApi implements LyftPublicApi
                                                 @Query("ride_type") String rideType) {
         List<RideType> rideTypes = new ArrayList<>();
         if (rideType == null) {
-            rideTypes.add(new RideType(LYFT_LINE, getDisplayNameForRideType(LYFT_LINE), 4, null, null, null));
-            rideTypes.add(new RideType(LYFT, getDisplayNameForRideType(LYFT), 4, null, null, null));
-            rideTypes.add(new RideType(LYFT_PLUS, getDisplayNameForRideType(LYFT_PLUS), 6, null, null, null));
-            rideTypes.add(new RideType(LYFT_PREMIER, getDisplayNameForRideType(LYFT_PREMIER), 4, null, null, null));
-            rideTypes.add(new RideType(LYFT_LUX, getDisplayNameForRideType(LYFT_LUX), 4, null, null, null));
-            rideTypes.add(new RideType(LYFT_LUX_SUV, getDisplayNameForRideType(LYFT_LUX_SUV), 6, null, null, null));
+            rideTypes.add(new RideType(LYFT_LINE, getDisplayNameForRideType(LYFT_LINE), 4, null, null));
+            rideTypes.add(new RideType(LYFT, getDisplayNameForRideType(LYFT), 4, null, null));
+            rideTypes.add(new RideType(LYFT_PLUS, getDisplayNameForRideType(LYFT_PLUS), 6, null, null));
+            rideTypes.add(new RideType(LYFT_PREMIER, getDisplayNameForRideType(LYFT_PREMIER), 4, null, null));
+            rideTypes.add(new RideType(LYFT_LUX, getDisplayNameForRideType(LYFT_LUX), 4, null, null));
+            rideTypes.add(new RideType(LYFT_LUX_SUV, getDisplayNameForRideType(LYFT_LUX_SUV), 6, null, null));
         } else {
-            rideTypes.add(new RideType(rideType, getDisplayNameForRideType(rideType), 6, null, null, null));
+            rideTypes.add(new RideType(rideType, getDisplayNameForRideType(rideType), 6, null, null));
         }
         RideTypesResponse rideTypesResponse = new RideTypesResponse(rideTypes);
         return delegate.returningResponse(rideTypesResponse).getRidetypes(lat, lng, rideType);


### PR DESCRIPTION
Create a default behaviour that throws an exception if a given endpoint returns a response that is only partially populated (i.e. not complete).

Since this is a rather strict behaviour, there are also changes to the LyftApiFactory class. The caller requesting for an API implementation can set a flag to disallow the default behaviour, and work with potentially partial data at their own risk.

The implementation summary is as follows:

1. Each response model implements a `ICompleteData`, which houses its validation logic inside a public `isValid()` method.
2. A `NullCheckErrorConverter` on the API implementation class checks if the returned model implements `ICompleteData`.
  - Yes: Invoke the top level `isValid()`. If it returns `false`, the converter throws a `PartialResponseException`. If it returns `true`, return the object untreated.
  - No: Return the object untreated.