### PR TITLE
[Networking] Document nullable fields in network responses

### DIFF
--- a/networking/src/main/java/com/lyft/networking/apiObjects/CostEstimate.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/CostEstimate.java
@@ -2,6 +2,7 @@ package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
 import com.lyft.networking.apiObjects.internal.Validatable;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -12,18 +13,21 @@ public class CostEstimate implements Validatable {
     /**
      * Ride type one of: (lyft, lyft_plus, lyft_line, lyft_premier, lyft_lux, lyft_luxsuv)
      */
+    @NotNull
     @SerializedName("ride_type")
     public final String ride_type;
 
     /**
      * A human readable description of the ride type.
      */
+    @NotNull
     @SerializedName("display_name")
     public final String display_name;
 
     /***
      *ISO 4217 currency code for the amount (e.g. USD).
      */
+    @NotNull
     @SerializedName("currency")
     public final String currency;
 
@@ -31,6 +35,7 @@ public class CostEstimate implements Validatable {
      * Estimated lower bound for trip cost, in minor units (cents). Estimates are not guaranteed,
      * and only provide a reasonable range based on current conditions.
      */
+    @NotNull
     @SerializedName("estimated_cost_cents_min")
     public final Integer estimated_cost_cents_min;
 
@@ -38,24 +43,28 @@ public class CostEstimate implements Validatable {
      * Estimated upper bound for trip cost, in minor units (cents). Estimates are not guaranteed,
      * and only provide a reasonable range based on current conditions.
      */
+    @NotNull
     @SerializedName("estimated_cost_cents_max")
     public final Integer estimated_cost_cents_max;
 
     /**
      * Estimated distance for this ride as expressed in miles.
      */
+    @NotNull
     @SerializedName("estimated_distance_miles")
     public final Double estimated_distance_miles;
 
     /**
      * Estimated time to get from the start location to the end as expressed in seconds.
      */
+    @NotNull
     @SerializedName("estimated_duration_seconds")
     public final Integer estimated_duration_seconds;
 
     /**
      * The current primetime value
      */
+    @NotNull
     @SerializedName("primetime_percentage")
     public final String primetime_percentage;
 
@@ -72,8 +81,8 @@ public class CostEstimate implements Validatable {
      *
      * A token that should be used to confirm that the user has accepted current Prime Time pricing.
      */
-    @Nullable
     @Deprecated
+    @Nullable
     @SerializedName("primetime_confirmation_token")
     public final String primetime_confirmation_token;
 

--- a/networking/src/main/java/com/lyft/networking/apiObjects/CostEstimateResponse.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/CostEstimateResponse.java
@@ -2,11 +2,13 @@ package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
 import com.lyft.networking.apiObjects.internal.Validatable;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
 public class CostEstimateResponse implements Validatable {
 
+    @NotNull
     @SerializedName("cost_estimates")
     public final List<CostEstimate> cost_estimates;
 

--- a/networking/src/main/java/com/lyft/networking/apiObjects/Eta.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/Eta.java
@@ -2,18 +2,22 @@ package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
 import com.lyft.networking.apiObjects.internal.Validatable;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Estimated Time of Arrival
  **/
 public class Eta implements Validatable {
 
+    @NotNull
     @SerializedName("ride_type")
     public final String ride_type;
 
+    @NotNull
     @SerializedName("display_name")
     public final String display_name;
 
+    @NotNull
     @SerializedName("eta_seconds")
     public final Integer eta_seconds;
 

--- a/networking/src/main/java/com/lyft/networking/apiObjects/EtaEstimateResponse.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/EtaEstimateResponse.java
@@ -2,11 +2,13 @@ package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
 import com.lyft.networking.apiObjects.internal.Validatable;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
 public class EtaEstimateResponse implements Validatable {
 
+    @NotNull
     @SerializedName("eta_estimates")
     public final List<Eta> eta_estimates;
 

--- a/networking/src/main/java/com/lyft/networking/apiObjects/LatLng.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/LatLng.java
@@ -2,12 +2,15 @@ package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
 import com.lyft.networking.apiObjects.internal.Validatable;
+import org.jetbrains.annotations.NotNull;
 
 public class LatLng implements Validatable {
 
+    @NotNull
     @SerializedName("lat")
     public final Double lat;
 
+    @NotNull
     @SerializedName("lng")
     public final Double lng;
 

--- a/networking/src/main/java/com/lyft/networking/apiObjects/MonetaryAmount.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/MonetaryAmount.java
@@ -1,22 +1,30 @@
 package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
+import com.lyft.networking.apiObjects.internal.Validatable;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Model representing monetary amount and currency
  */
 
-public class MonetaryAmount
-{
+public class MonetaryAmount implements Validatable {
     /**
      * The monetary amount
      */
+    @NotNull
     @SerializedName("amount")
     public int amount;
 
     /**
      * The ISO 4217 currency code for the amount (e.g. USD).
      */
+    @NotNull
     @SerializedName("currency")
     public String currency;
+
+    @Override
+    public boolean isValid() {
+        return currency != null;
+    }
 }

--- a/networking/src/main/java/com/lyft/networking/apiObjects/NearbyDriver.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/NearbyDriver.java
@@ -2,11 +2,13 @@ package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
 import com.lyft.networking.apiObjects.internal.Validatable;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
 public class NearbyDriver implements Validatable {
 
+    @NotNull
     @SerializedName("locations")
     public final List<LatLng> locations;
 

--- a/networking/src/main/java/com/lyft/networking/apiObjects/NearbyDriversByRideType.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/NearbyDriversByRideType.java
@@ -2,14 +2,17 @@ package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
 import com.lyft.networking.apiObjects.internal.Validatable;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
 public class NearbyDriversByRideType implements Validatable {
 
+    @NotNull
     @SerializedName("ride_type")
     public final String ride_type;
 
+    @NotNull
     @SerializedName("drivers")
     public final List<NearbyDriver> drivers;
 

--- a/networking/src/main/java/com/lyft/networking/apiObjects/NearbyDriversResponse.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/NearbyDriversResponse.java
@@ -2,11 +2,13 @@ package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
 import com.lyft.networking.apiObjects.internal.Validatable;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
 public class NearbyDriversResponse implements Validatable {
 
+    @NotNull
     @SerializedName("nearby_drivers")
     public final List<NearbyDriversByRideType> nearby_drivers;
 

--- a/networking/src/main/java/com/lyft/networking/apiObjects/PricingDetails.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/PricingDetails.java
@@ -2,27 +2,35 @@ package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
 import com.lyft.networking.apiObjects.internal.Validatable;
+import org.jetbrains.annotations.NotNull;
 
 public class PricingDetails implements Validatable {
 
+    @NotNull
     @SerializedName("base_charge")
     public final Integer base_charge;
 
+    @NotNull
     @SerializedName("cancel_penalty_amount")
     public final Integer cancel_penalty_amount;
 
+    @NotNull
     @SerializedName("cost_minimum")
     public final Integer cost_minimum;
 
+    @NotNull
     @SerializedName("cost_per_mile")
     public final Integer cost_per_mile;
 
+    @NotNull
     @SerializedName("cost_per_minute")
     public final Integer cost_per_minute;
 
+    @NotNull
     @SerializedName("currency")
     public final String currency;
 
+    @NotNull
     @SerializedName("trust_and_service")
     public final Integer trust_and_service;
 

--- a/networking/src/main/java/com/lyft/networking/apiObjects/RideCancellation.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/RideCancellation.java
@@ -1,22 +1,29 @@
 package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
+import com.lyft.networking.apiObjects.internal.Validatable;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Created by awaht on 10/4/2017.
  */
 
-public class RideCancellation extends MonetaryAmount
-{
+public class RideCancellation extends MonetaryAmount implements Validatable {
     /**
      * Token used to confirm the fee when cancelling a request.
      */
+    @NotNull
     @SerializedName("token")
-    public String token ;
+    public String token;
 
     /**
      * How long, in seconds, before the token expires.
      */
     @SerializedName("token_duration")
-    public int token_duration ;
+    public int token_duration;
+
+    @Override
+    public boolean isValid() {
+        return token != null && super.isValid();
+    }
 }

--- a/networking/src/main/java/com/lyft/networking/apiObjects/RideHistory.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/RideHistory.java
@@ -2,6 +2,7 @@ package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
 import com.lyft.networking.apiObjects.internal.Validatable;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -9,32 +10,40 @@ import org.jetbrains.annotations.Nullable;
  */
 
 public class RideHistory implements Validatable {
+
     /**
      * Ride id
      */
+    @NotNull
     @SerializedName("ride_id")
     public String ride_id;
+
     /**
      * Ride type expressed as one of (lyft, lyft_plus, lyft_line, etc).
      */
+    @NotNull
     @SerializedName("ride_type")
     public String ride_type;
+
     /**
      * Ride status expressed as one of (pending, accepted, arrived,
      * pickedUp, droppedOff, canceled, unknown).
      */
+    @NotNull
     @SerializedName("status")
     public String status;
 
     /**
      * Prime Time percentage applied to the base price
      */
+    @NotNull
     @SerializedName("primetime_percentage")
     public String primetime_percentage;
 
     /**
      * The ISO8601 Timestamp of when the request was made.
      */
+    @NotNull
     @SerializedName("requested_at")
     public String requested_at;
 
@@ -83,6 +92,7 @@ public class RideHistory implements Validatable {
     @Nullable
     @SerializedName("feedback")
     public String feedback;
+
     /**
      * The array of actors who may cancel the ride at this point (driver, passenger, dispatcher).
      */
@@ -93,18 +103,20 @@ public class RideHistory implements Validatable {
     /**
      * Actual location of passenger pickup.
      */
+    @Nullable
     @SerializedName("pickup")
     public LyftLocation pickup;
 
     /**
      * Requested location for passenger drop off.
      */
+    @Nullable
     @SerializedName("destination")
-
     public LyftLocation destination;
     /**
      * Actual location of passenger drop off
     */
+    @Nullable
     @SerializedName("dropoff")
     public LyftLocation dropoff;
 
@@ -119,44 +131,55 @@ public class RideHistory implements Validatable {
     /**
      * Requested location for passenger pickup.
      */
+    @Nullable
     @SerializedName("origin")
     public EtaLocation origin;
 
     /**
      * The passenger meta data
      */
+    @Nullable
     @SerializedName("passenger")
     public LyftUser passenger;
 
     /**
      * Driver meta data
      */
+    @Nullable
     @SerializedName("driver")
     public LyftDriver driver;
+
     /**
      * Total cost for the ride. Available after ride status changes to droppedOff and
      * the passenger has rated and paid for the ride, plus some processing time.
      */
+    @Nullable
     @SerializedName("price")
     public RidePrice price;
 
     /**
      * The cost of cancellation if there would be a penalty
      */
+    @Nullable
     @SerializedName("cancellation_price")
     public RideCancellation cancellation_price;
+
     /**
      * Vehicle meta data
      */
+    @Nullable
     @SerializedName("vehicle")
     public Vehicle vehicle;
 
+    @Nullable
     @SerializedName("distance_miles")
     public double distance_miles;
 
+    @Nullable
     @SerializedName("duration_seconds")
     public double duration_seconds;
 
+    @Nullable
     @SerializedName("rating")
     public int rating;
 

--- a/networking/src/main/java/com/lyft/networking/apiObjects/RideRequest.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/RideRequest.java
@@ -1,5 +1,8 @@
 package com.lyft.networking.apiObjects;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 /**
  * Model containing information necessary to request a
  * ride on the Lyft Platfrom
@@ -9,11 +12,13 @@ public class RideRequest
     /**
      * Required: Pickup location
      */
+    @NotNull
     public LyftLocation origin;
 
     /**
      * Drop off location
      */
+    @Nullable
     public LyftLocation destination;
 
     /**
@@ -21,6 +26,7 @@ public class RideRequest
      * Availability - Ride Types for acceptable values (possible examples
      * include: lyft, lyft_plus, etc).
      */
+    @NotNull
     public String  ride_type;
 
     /**
@@ -28,6 +34,7 @@ public class RideRequest
      * Deprecated, use {@link RideRequest#cost_token} instead.
      */
     @Deprecated
+    @Nullable
     public String primetime_confirmation_token;
 
     /**
@@ -40,6 +47,7 @@ public class RideRequest
      * also in the Availability - Ride Estimates response when querying that
      * endpoint with a user context.
      */
+    @Nullable
     public String cost_token;
 
     public RideRequest(LyftLocation origin, LyftLocation destination, String ride_type) { this(origin, destination, ride_type, null);}

--- a/networking/src/main/java/com/lyft/networking/apiObjects/RideRequestResponse.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/RideRequestResponse.java
@@ -2,6 +2,8 @@ package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
 import com.lyft.networking.apiObjects.internal.Validatable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Response model for requests for Rides on the Lyft Platform
@@ -11,36 +13,42 @@ public class RideRequestResponse implements Validatable {
     /**
      * Requested ride ID.
      */
+    @NotNull
     @SerializedName("ride_id")
     public String ride_id;
 
     /**
      * Ride type will correspond to the ride_type request body parameter.
      */
+    @NotNull
     @SerializedName("ride_type")
     public String ride_type;
 
     /**
      * Ride status for a newly requested ride will be returned as pending.
      */
+    @NotNull
     @SerializedName("status")
     public String status;
 
     /**
      * Requested location for passenger pickup.
      */
+    @Nullable
     @SerializedName("origin")
     public LyftLocation origin;
 
     /**
      * Requested location for passenger drop off.
      */
+    @Nullable
     @SerializedName("destination")
     public LyftLocation destination;
 
     /**
      * The passenger
      */
+    @Nullable
     @SerializedName("passenger")
     public LyftUser passenger;
 
@@ -48,9 +56,6 @@ public class RideRequestResponse implements Validatable {
     public boolean isValid() {
         return ride_id != null
                 && ride_type != null
-                && status != null
-                && origin.isValid()
-                && destination.isValid()
-                && passenger.isValid();
+                && status != null;
     }
 }

--- a/networking/src/main/java/com/lyft/networking/apiObjects/RideType.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/RideType.java
@@ -2,16 +2,20 @@ package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
 import com.lyft.networking.apiObjects.internal.Validatable;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class RideType implements Validatable {
 
+    @NotNull
     @SerializedName("ride_type")
     public final String ride_type;
 
+    @NotNull
     @SerializedName("display_name")
     public final String display_name;
 
+    @NotNull
     @SerializedName("seats")
     public final Integer seats;
 
@@ -19,19 +23,26 @@ public class RideType implements Validatable {
     @SerializedName("image_url")
     public final String image_url;
 
+    @NotNull
     @SerializedName("pricing_details")
     public final PricingDetails pricing_details;
+
+    @Nullable
+    @SerializedName("scheduled_pricing_details")
+    public final PricingDetails scheduled_pricing_details;
 
     public RideType(String ride_type,
                     String display_name,
                     Integer seats,
                     String image_url,
-                    PricingDetails pricing_details) {
+                    PricingDetails pricing_details,
+                    PricingDetails scheduled_pricing_details) {
         this.ride_type = ride_type;
         this.display_name = display_name;
         this.seats = seats;
         this.image_url = image_url;
         this.pricing_details = pricing_details;
+        this.scheduled_pricing_details = scheduled_pricing_details;
     }
 
     @Override
@@ -44,6 +55,7 @@ public class RideType implements Validatable {
         sb.append("  seats: ").append(seats).append("\n");
         sb.append("  image_url: ").append(image_url).append("\n");
         sb.append("  pricing_details: ").append(pricing_details).append("\n");
+        sb.append("  scheduled_pricing_details: ").append(scheduled_pricing_details).append("\n");
         sb.append("}\n");
         return sb.toString();
     }

--- a/networking/src/main/java/com/lyft/networking/apiObjects/RideTypesResponse.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/RideTypesResponse.java
@@ -2,11 +2,13 @@ package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
 import com.lyft.networking.apiObjects.internal.Validatable;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
 public class RideTypesResponse implements Validatable {
 
+    @NotNull
     @SerializedName("ride_types")
     public final List<RideType> ride_types;
 

--- a/networking/src/main/java/com/lyft/networking/apiObjects/UserRideHistoryResponse.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/UserRideHistoryResponse.java
@@ -10,6 +10,8 @@ import java.util.List;
  */
 
 public class UserRideHistoryResponse implements Validatable {
+
+
     @SerializedName("ride_history")
     public List<RideHistory> ride_history;
 

--- a/networking/src/main/java/com/lyft/networking/apiObjects/UserRideHistoryResponse.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/UserRideHistoryResponse.java
@@ -2,6 +2,7 @@ package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
 import com.lyft.networking.apiObjects.internal.Validatable;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
@@ -11,7 +12,7 @@ import java.util.List;
 
 public class UserRideHistoryResponse implements Validatable {
 
-
+    @NotNull
     @SerializedName("ride_history")
     public List<RideHistory> ride_history;
 

--- a/test-utils/src/main/java/com/lyft/testutils/MockLyftPublicApi.java
+++ b/test-utils/src/main/java/com/lyft/testutils/MockLyftPublicApi.java
@@ -119,14 +119,14 @@ public class MockLyftPublicApi implements LyftPublicApi
                                                 @Query("ride_type") String rideType) {
         List<RideType> rideTypes = new ArrayList<>();
         if (rideType == null) {
-            rideTypes.add(new RideType(LYFT_LINE, getDisplayNameForRideType(LYFT_LINE), 4, null, null));
-            rideTypes.add(new RideType(LYFT, getDisplayNameForRideType(LYFT), 4, null, null));
-            rideTypes.add(new RideType(LYFT_PLUS, getDisplayNameForRideType(LYFT_PLUS), 6, null, null));
-            rideTypes.add(new RideType(LYFT_PREMIER, getDisplayNameForRideType(LYFT_PREMIER), 4, null, null));
-            rideTypes.add(new RideType(LYFT_LUX, getDisplayNameForRideType(LYFT_LUX), 4, null, null));
-            rideTypes.add(new RideType(LYFT_LUX_SUV, getDisplayNameForRideType(LYFT_LUX_SUV), 6, null, null));
+            rideTypes.add(new RideType(LYFT_LINE, getDisplayNameForRideType(LYFT_LINE), 4, null, null, null));
+            rideTypes.add(new RideType(LYFT, getDisplayNameForRideType(LYFT), 4, null, null, null));
+            rideTypes.add(new RideType(LYFT_PLUS, getDisplayNameForRideType(LYFT_PLUS), 6, null, null, null));
+            rideTypes.add(new RideType(LYFT_PREMIER, getDisplayNameForRideType(LYFT_PREMIER), 4, null, null, null));
+            rideTypes.add(new RideType(LYFT_LUX, getDisplayNameForRideType(LYFT_LUX), 4, null, null, null));
+            rideTypes.add(new RideType(LYFT_LUX_SUV, getDisplayNameForRideType(LYFT_LUX_SUV), 6, null, null, null));
         } else {
-            rideTypes.add(new RideType(rideType, getDisplayNameForRideType(rideType), 6, null, null));
+            rideTypes.add(new RideType(rideType, getDisplayNameForRideType(rideType), 6, null, null, null));
         }
         RideTypesResponse rideTypesResponse = new RideTypesResponse(rideTypes);
         return delegate.returningResponse(rideTypesResponse).getRidetypes(lat, lng, rideType);


### PR DESCRIPTION
Per title. This PR adds `@Nullable` and `@NotNull` annotations to the Response models returned by network calls, so client developers can have visibility into what should and shouldn't be `null` values.