### PR TITLE
[Networking] Document nullable fields in network responses

### DIFF
--- a/networking/src/main/java/com/lyft/networking/apiObjects/CostEstimate.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/CostEstimate.java
@@ -2,6 +2,7 @@ package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
 import com.lyft.networking.apiObjects.internal.Validatable;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -12,18 +13,21 @@ public class CostEstimate implements Validatable {
     /**
      * Ride type one of: (lyft, lyft_plus, lyft_line, lyft_premier, lyft_lux, lyft_luxsuv)
      */
+    @NotNull
     @SerializedName("ride_type")
     public final String ride_type;
 
     /**
      * A human readable description of the ride type.
      */
+    @NotNull
     @SerializedName("display_name")
     public final String display_name;
 
     /***
      *ISO 4217 currency code for the amount (e.g. USD).
      */
+    @NotNull
     @SerializedName("currency")
     public final String currency;
 
@@ -31,6 +35,7 @@ public class CostEstimate implements Validatable {
      * Estimated lower bound for trip cost, in minor units (cents). Estimates are not guaranteed,
      * and only provide a reasonable range based on current conditions.
      */
+    @NotNull
     @SerializedName("estimated_cost_cents_min")
     public final Integer estimated_cost_cents_min;
 
@@ -38,48 +43,34 @@ public class CostEstimate implements Validatable {
      * Estimated upper bound for trip cost, in minor units (cents). Estimates are not guaranteed,
      * and only provide a reasonable range based on current conditions.
      */
+    @NotNull
     @SerializedName("estimated_cost_cents_max")
     public final Integer estimated_cost_cents_max;
 
     /**
      * Estimated distance for this ride as expressed in miles.
      */
+    @NotNull
     @SerializedName("estimated_distance_miles")
     public final Double estimated_distance_miles;
 
     /**
      * Estimated time to get from the start location to the end as expressed in seconds.
      */
+    @NotNull
     @SerializedName("estimated_duration_seconds")
     public final Integer estimated_duration_seconds;
 
     /**
      * The current primetime value
      */
+    @NotNull
     @SerializedName("primetime_percentage")
     public final String primetime_percentage;
 
-    /**
-     * A token that should be used to confirm that the user has accepted current Prime Time
-     * and/or fixed price charges. See note above.
-     */
-    @Nullable
-    @SerializedName("cost_token")
-    public final String cost_token;
-
-    /**
-     * @Deprecated use {@link #cost_token} instead.
-     *
-     * A token that should be used to confirm that the user has accepted current Prime Time pricing.
-     */
-    @Nullable
-    @Deprecated
-    @SerializedName("primetime_confirmation_token")
-    public final String primetime_confirmation_token;
-
     public CostEstimate(String ride_type, String display_name, String currency, Integer estimated_cost_cents_min,
                         Integer estimated_cost_cents_max, Double estimated_distance_miles, Integer estimated_duration_seconds,
-                        String primetime_percentage, String primetime_confirmation_token, String cost_token) {
+                        String primetime_percentage) {
         this.ride_type = ride_type;
         this.display_name = display_name;
         this.currency = currency;
@@ -88,8 +79,6 @@ public class CostEstimate implements Validatable {
         this.estimated_distance_miles = estimated_distance_miles;
         this.estimated_duration_seconds = estimated_duration_seconds;
         this.primetime_percentage = primetime_percentage;
-        this.primetime_confirmation_token = primetime_confirmation_token;
-        this.cost_token = cost_token;
     }
 
     @Override
@@ -105,8 +94,6 @@ public class CostEstimate implements Validatable {
         sb.append("  estimated_distance_miles: ").append(estimated_distance_miles).append("\n");
         sb.append("  estimated_duration_seconds: ").append(estimated_duration_seconds).append("\n");
         sb.append("  primetime_percentage: ").append(primetime_percentage).append("\n");
-        sb.append("  primetime_confirmation_token: ").append(primetime_confirmation_token).append("\n");
-        sb.append("  cost_token: ").append(cost_token).append("\n");
         sb.append("}\n");
         return sb.toString();
     }

--- a/networking/src/main/java/com/lyft/networking/apiObjects/CostEstimate.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/CostEstimate.java
@@ -26,38 +26,53 @@ public class CostEstimate implements Validatable {
 
     /***
      *ISO 4217 currency code for the amount (e.g. USD).
+     *
+     * Can be returned as null: will only be populated if the corresponding request specified
+     * a destination.
      */
-    @NotNull
+    @Nullable
     @SerializedName("currency")
     public final String currency;
 
     /**
      * Estimated lower bound for trip cost, in minor units (cents). Estimates are not guaranteed,
      * and only provide a reasonable range based on current conditions.
+     *
+     * Can be returned as null: will only be populated if the corresponding request specified
+     * a destination.
      */
-    @NotNull
+    @Nullable
     @SerializedName("estimated_cost_cents_min")
     public final Integer estimated_cost_cents_min;
 
     /**
      * Estimated upper bound for trip cost, in minor units (cents). Estimates are not guaranteed,
      * and only provide a reasonable range based on current conditions.
+     *
+     * Can be returned as null: will only be populated if the corresponding request specified
+     * a destination.
      */
-    @NotNull
+    @Nullable
     @SerializedName("estimated_cost_cents_max")
     public final Integer estimated_cost_cents_max;
 
     /**
      * Estimated distance for this ride as expressed in miles.
+     *
+     * Can be returned as null: will only be populated if the corresponding request specified
+     * a destination.
      */
-    @NotNull
+    @Nullable
     @SerializedName("estimated_distance_miles")
     public final Double estimated_distance_miles;
 
     /**
      * Estimated time to get from the start location to the end as expressed in seconds.
+     *
+     * Can be returned as null: will only be populated if the corresponding request specified
+     * a destination.
      */
-    @NotNull
+    @Nullable
     @SerializedName("estimated_duration_seconds")
     public final Integer estimated_duration_seconds;
 
@@ -102,11 +117,6 @@ public class CostEstimate implements Validatable {
     public boolean isValid() {
         return ride_type != null
                 && display_name != null
-                && currency != null
-                && estimated_cost_cents_min != null
-                && estimated_cost_cents_max != null
-                && estimated_distance_miles != null
-                && estimated_duration_seconds != null
                 && primetime_percentage != null;
     }
 }

--- a/networking/src/main/java/com/lyft/networking/apiObjects/CostEstimateResponse.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/CostEstimateResponse.java
@@ -3,10 +3,13 @@ package com.lyft.networking.apiObjects;
 import com.google.gson.annotations.SerializedName;
 import com.lyft.networking.apiObjects.internal.Validatable;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.List;
 
 public class CostEstimateResponse implements Validatable {
 
+    @NotNull
     @SerializedName("cost_estimates")
     public final List<CostEstimate> cost_estimates;
 
@@ -26,6 +29,10 @@ public class CostEstimateResponse implements Validatable {
 
     @Override
     public boolean isValid() {
+        if (cost_estimates == null) {
+            return false;
+        }
+
         for (CostEstimate costEstimate : cost_estimates) {
             if (!costEstimate.isValid()) {
                 return false;

--- a/networking/src/main/java/com/lyft/networking/apiObjects/Eta.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/Eta.java
@@ -3,17 +3,22 @@ package com.lyft.networking.apiObjects;
 import com.google.gson.annotations.SerializedName;
 import com.lyft.networking.apiObjects.internal.Validatable;
 
+import org.jetbrains.annotations.NotNull;
+
 /**
  * Estimated Time of Arrival
  **/
 public class Eta implements Validatable {
 
+    @NotNull
     @SerializedName("ride_type")
     public final String ride_type;
 
+    @NotNull
     @SerializedName("display_name")
     public final String display_name;
 
+    @NotNull
     @SerializedName("eta_seconds")
     public final Integer eta_seconds;
 

--- a/networking/src/main/java/com/lyft/networking/apiObjects/EtaEstimateResponse.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/EtaEstimateResponse.java
@@ -3,10 +3,13 @@ package com.lyft.networking.apiObjects;
 import com.google.gson.annotations.SerializedName;
 import com.lyft.networking.apiObjects.internal.Validatable;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.List;
 
 public class EtaEstimateResponse implements Validatable {
 
+    @NotNull
     @SerializedName("eta_estimates")
     public final List<Eta> eta_estimates;
 
@@ -26,6 +29,10 @@ public class EtaEstimateResponse implements Validatable {
 
     @Override
     public boolean isValid() {
+        if (eta_estimates == null) {
+            return false;
+        }
+
         for (Eta etaEstimate : eta_estimates) {
             if (!etaEstimate.isValid()) {
                 return false;

--- a/networking/src/main/java/com/lyft/networking/apiObjects/NearbyDriver.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/NearbyDriver.java
@@ -3,10 +3,13 @@ package com.lyft.networking.apiObjects;
 import com.google.gson.annotations.SerializedName;
 import com.lyft.networking.apiObjects.internal.Validatable;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.List;
 
 public class NearbyDriver implements Validatable {
 
+    @NotNull
     @SerializedName("locations")
     public final List<LatLng> locations;
 
@@ -26,6 +29,10 @@ public class NearbyDriver implements Validatable {
 
     @Override
     public boolean isValid() {
+        if (locations == null) {
+            return false;
+        }
+
         for (LatLng location : locations) {
             if (!location.isValid()) {
                 return false;

--- a/networking/src/main/java/com/lyft/networking/apiObjects/NearbyDriversByRideType.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/NearbyDriversByRideType.java
@@ -3,13 +3,17 @@ package com.lyft.networking.apiObjects;
 import com.google.gson.annotations.SerializedName;
 import com.lyft.networking.apiObjects.internal.Validatable;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.List;
 
 public class NearbyDriversByRideType implements Validatable {
 
+    @NotNull
     @SerializedName("ride_type")
     public final String ride_type;
 
+    @NotNull
     @SerializedName("drivers")
     public final List<NearbyDriver> drivers;
 
@@ -31,6 +35,10 @@ public class NearbyDriversByRideType implements Validatable {
 
     @Override
     public boolean isValid() {
+        if (drivers == null) {
+            return false;
+        }
+
         for (NearbyDriver driver : drivers) {
             if (!driver.isValid()) {
                 return false;

--- a/networking/src/main/java/com/lyft/networking/apiObjects/NearbyDriversResponse.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/NearbyDriversResponse.java
@@ -3,10 +3,13 @@ package com.lyft.networking.apiObjects;
 import com.google.gson.annotations.SerializedName;
 import com.lyft.networking.apiObjects.internal.Validatable;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.List;
 
 public class NearbyDriversResponse implements Validatable {
 
+    @NotNull
     @SerializedName("nearby_drivers")
     public final List<NearbyDriversByRideType> nearby_drivers;
 
@@ -26,6 +29,10 @@ public class NearbyDriversResponse implements Validatable {
 
     @Override
     public boolean isValid() {
+        if (nearby_drivers == null) {
+            return false;
+        }
+
         for (NearbyDriversByRideType nearbyDriver : nearby_drivers) {
             if (!nearbyDriver.isValid()) {
                 return false;

--- a/networking/src/main/java/com/lyft/networking/apiObjects/PricingDetails.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/PricingDetails.java
@@ -3,26 +3,35 @@ package com.lyft.networking.apiObjects;
 import com.google.gson.annotations.SerializedName;
 import com.lyft.networking.apiObjects.internal.Validatable;
 
+import org.jetbrains.annotations.NotNull;
+
 public class PricingDetails implements Validatable {
 
+    @NotNull
     @SerializedName("base_charge")
     public final Integer base_charge;
 
+    @NotNull
     @SerializedName("cancel_penalty_amount")
     public final Integer cancel_penalty_amount;
 
+    @NotNull
     @SerializedName("cost_minimum")
     public final Integer cost_minimum;
 
+    @NotNull
     @SerializedName("cost_per_mile")
     public final Integer cost_per_mile;
 
+    @NotNull
     @SerializedName("cost_per_minute")
     public final Integer cost_per_minute;
 
+    @NotNull
     @SerializedName("currency")
     public final String currency;
 
+    @NotNull
     @SerializedName("trust_and_service")
     public final Integer trust_and_service;
 

--- a/networking/src/main/java/com/lyft/networking/apiObjects/RideType.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/RideType.java
@@ -2,16 +2,21 @@ package com.lyft.networking.apiObjects;
 
 import com.google.gson.annotations.SerializedName;
 import com.lyft.networking.apiObjects.internal.Validatable;
+
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class RideType implements Validatable {
 
+    @NotNull
     @SerializedName("ride_type")
     public final String ride_type;
 
+    @NotNull
     @SerializedName("display_name")
     public final String display_name;
 
+    @NotNull
     @SerializedName("seats")
     public final Integer seats;
 
@@ -19,6 +24,7 @@ public class RideType implements Validatable {
     @SerializedName("image_url")
     public final String image_url;
 
+    @NotNull
     @SerializedName("pricing_details")
     public final PricingDetails pricing_details;
 
@@ -53,6 +59,6 @@ public class RideType implements Validatable {
         return ride_type != null
                 && display_name != null
                 && seats != null
-                && pricing_details.isValid();
+                && pricing_details != null && pricing_details.isValid();
     }
 }

--- a/networking/src/main/java/com/lyft/networking/apiObjects/RideTypesResponse.java
+++ b/networking/src/main/java/com/lyft/networking/apiObjects/RideTypesResponse.java
@@ -3,10 +3,13 @@ package com.lyft.networking.apiObjects;
 import com.google.gson.annotations.SerializedName;
 import com.lyft.networking.apiObjects.internal.Validatable;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.List;
 
 public class RideTypesResponse implements Validatable {
 
+    @NotNull
     @SerializedName("ride_types")
     public final List<RideType> ride_types;
 
@@ -26,6 +29,10 @@ public class RideTypesResponse implements Validatable {
 
     @Override
     public boolean isValid() {
+        if (ride_types == null) {
+            return false;
+        }
+        
         for (RideType rideType : ride_types) {
             if (!rideType.isValid()) {
                 return false;

--- a/test-utils/src/main/java/com/lyft/testutils/MockLyftApi.java
+++ b/test-utils/src/main/java/com/lyft/testutils/MockLyftApi.java
@@ -143,7 +143,7 @@ public class MockLyftApi implements LyftApi
     }
 
     private static CostEstimate createCostEstimateForRideType(String rideType) {
-        return new CostEstimate(rideType, getDisplayNameForRideType(rideType), "USD", null, null, null, null, null, null, null);
+        return new CostEstimate(rideType, getDisplayNameForRideType(rideType), "USD", null, null, null, null, null);
     }
 
     private static boolean isValidRideType(String rideType) {


### PR DESCRIPTION
Per title. This PR adds @Nullable and @NotNull annotations to the Response models returned by network calls, so client developers can have visibility into what should and shouldn't be null values.

This PR should align the returned models to the iOS SDK counterparts.