### PR TITLE
Copy promo code when in Builder constructor.

### DIFF
--- a/lyft-button/src/main/java/com/lyft/lyftbutton/RideParams.java
+++ b/lyft-button/src/main/java/com/lyft/lyftbutton/RideParams.java
@@ -110,6 +110,7 @@ public class RideParams {
             this.dropoffAddr = rideParams.dropoffAddr;
             this.dropoffLat = rideParams.dropoffLat;
             this.dropoffLng = rideParams.dropoffLng;
+            this.promoCode = rideParams.promoCode;
         }
 
         public Builder setRideTypeEnum(RideTypeEnum rideTypeEnum) {


### PR DESCRIPTION
Calling `newBuilder` on an instance of `RideParams` does not copy the `promoCode` to the new `RideParams.Builder` instance. This bug manifests via `LyftButtonCallManager.load` whenever `load` is called for a `LyftButton`.