### PR TITLE
Updated Package visibility for API 30 and above

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
+# defect/package-visibility-in-android
+
+- **Issue**: `intent.resolveActivity(context.getPackageManager())` evaluated to `null` when targetSDK is 30 and above
+<img width="1251" alt="Screen Shot 2022-03-11 at 2 05 36 PM" src="https://user-images.githubusercontent.com/83723306/157934972-f81074d6-4eca-4996-9b79-21a1733dc42f.png">
+
+- **Cause**: Android 11 introduced changes related to package visibility. (https://developer.android.com/about/versions/11/privacy/package-visibility)
+
+- **Fix**: 
+  - Updated Gradle version from `4.10.1` to `5.4.1`, and Android Gradle Plugin from `3.3.2` to `3.5.4`
+  - Updated AndroidTargetSDK from `23` to `30`
+  - Added a <queries> element in the Android manifest
+
+- **Before Fix Sample Video:** 
+
+https://user-images.githubusercontent.com/83723306/157935785-0d32181c-20d4-42b9-98af-2212bd3a696d.mp4
+
+- **After Fix Sample Video:** 
+
+https://user-images.githubusercontent.com/83723306/157935477-3695dd17-5ad3-422e-8b1f-a882f125ad9d.mp4
+
+https://user-images.githubusercontent.com/83723306/157935497-d20b923e-00d1-4680-991a-0a2595383f6f.mp4
+
 # Lyft Android SDK
 
 The Official Lyft Android SDK makes it easy to integrate Lyft into your app. More specifically, it provides:

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:3.5.4'
     }
 }
 
@@ -35,7 +35,7 @@ subprojects {
     ext.androidCompileSDK = 28
     ext.androidMinSdk = 15
     ext.androidSupportLibrariesVersion = '28.0.0'
-    ext.androidTargetSDK = 23
+    ext.androidTargetSDK = 30
     ext.googlePlayVersion = '17.0.0'
     ext.jetbrainsVersion = '15.0'
     ext.junitVersion = '4.12'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 28 10:00:20 PST 2015
+#Fri Mar 11 15:23:35 EST 2022
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/lyft-button/src/main/AndroidManifest.xml
+++ b/lyft-button/src/main/AndroidManifest.xml
@@ -1,4 +1,11 @@
 <manifest package="com.lyft.lyftbutton"
-    >
-
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <queries>
+        <package android:name="me.lyft.android" />
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="https" />
+        </intent>
+    </queries>
 </manifest>


### PR DESCRIPTION
Closes #25 
- **Issue**: `intent.resolveActivity(context.getPackageManager())` evaluated to `null` when targetSDK is 30 and above
<img width="1251" alt="Screen Shot 2022-03-11 at 2 05 36 PM" src="https://user-images.githubusercontent.com/83723306/157934972-f81074d6-4eca-4996-9b79-21a1733dc42f.png">

- **Cause**: Android 11 introduced changes related to package visibility. (https://developer.android.com/about/versions/11/privacy/package-visibility)

- **Fix**: 
  - Updated Gradle version from `4.10.1` to `5.4.1`, and Android Gradle Plugin from `3.3.2` to `3.5.4`
  - Updated AndroidTargetSDK from `23` to `30`
  - Added a <queries> element in the Android manifest

- **Before Fix Sample Video:** 

https://user-images.githubusercontent.com/83723306/157935785-0d32181c-20d4-42b9-98af-2212bd3a696d.mp4

- **After Fix Sample Video:** 

https://user-images.githubusercontent.com/83723306/157935477-3695dd17-5ad3-422e-8b1f-a882f125ad9d.mp4

https://user-images.githubusercontent.com/83723306/157935497-d20b923e-00d1-4680-991a-0a2595383f6f.mp4